### PR TITLE
feat: redesign landing and add number guessing widget

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,2 +1,398 @@
-* { box-sizing: border-box; }
-html, body { margin: 0; padding: 0; }
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  color-scheme: dark;
+  background-color: #050505;
+  color: #f5ede0;
+}
+
+body {
+  min-height: 100dvh;
+  background:
+    radial-gradient(120% 120% at 50% 0%, rgba(255, 109, 36, 0.15), transparent 55%),
+    radial-gradient(85% 85% at 0% 100%, rgba(255, 144, 43, 0.16), transparent 62%),
+    linear-gradient(180deg, #0d0d0d 0%, #050505 70%, #040404 100%);
+  color: inherit;
+}
+
+.theme-body {
+  font-family: 'Rajdhani', 'Exo 2', 'Segoe UI', 'Helvetica Neue', sans-serif;
+  letter-spacing: 0.01em;
+}
+
+a {
+  color: #ff914d;
+  text-underline-offset: 4px;
+}
+
+a:hover {
+  color: #ffb873;
+}
+
+.welcome-page {
+  position: relative;
+  min-height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 5rem clamp(1.5rem, 5vw, 4rem);
+  overflow: hidden;
+}
+
+.welcome-page::before,
+.welcome-page::after {
+  content: '';
+  position: fixed;
+  top: 3.5%;
+  bottom: 3.5%;
+  width: 34px;
+  pointer-events: none;
+  border-radius: 999px;
+  background: repeating-linear-gradient(
+    to bottom,
+    rgba(255, 145, 77, 0.9) 0,
+    rgba(255, 145, 77, 0.9) 14px,
+    rgba(255, 145, 77, 0.25) 14px,
+    rgba(255, 145, 77, 0.25) 28px
+  );
+  box-shadow: 0 0 35px rgba(255, 120, 40, 0.25);
+}
+
+.welcome-page::before {
+  left: max(env(safe-area-inset-left), 12px);
+  transform: skewY(-2deg);
+}
+
+.welcome-page::after {
+  right: max(env(safe-area-inset-right), 12px);
+  transform: skewY(2deg);
+}
+
+.zipper-strip {
+  position: absolute;
+  left: 9%;
+  right: 9%;
+  height: 26px;
+  border-radius: 999px;
+  pointer-events: none;
+  background: repeating-linear-gradient(
+    to right,
+    rgba(255, 145, 77, 0.82) 0,
+    rgba(255, 145, 77, 0.82) 40px,
+    rgba(255, 145, 77, 0.18) 40px,
+    rgba(255, 145, 77, 0.18) 80px
+  );
+  box-shadow: 0 0 30px rgba(255, 120, 40, 0.18);
+}
+
+.zipper-strip.top {
+  top: 3%;
+}
+
+.zipper-strip.bottom {
+  bottom: 3%;
+}
+
+.zipper-frame {
+  position: relative;
+  z-index: 1;
+  max-width: 960px;
+  width: min(960px, 100%);
+  background: linear-gradient(145deg, rgba(20, 20, 20, 0.9), rgba(6, 6, 6, 0.95));
+  border-radius: 26px;
+  border: 1px solid rgba(255, 140, 66, 0.4);
+  box-shadow:
+    0 20px 60px rgba(0, 0, 0, 0.45),
+    0 0 0 1px rgba(255, 140, 66, 0.2);
+  padding: clamp(2.5rem, 3vw, 3.5rem);
+  display: grid;
+  gap: clamp(2rem, 3vw, 3rem);
+}
+
+.hero {
+  display: grid;
+  gap: 0.5rem;
+  text-align: center;
+}
+
+.hero__subtitle {
+  font-size: clamp(0.85rem, 2vw, 1.05rem);
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: rgba(255, 160, 95, 0.68);
+}
+
+.hero__title {
+  margin: 0;
+  font-size: clamp(2.8rem, 5vw, 3.8rem);
+  color: #ffe1ca;
+  text-shadow: 0 10px 30px rgba(255, 120, 40, 0.2);
+}
+
+.hero__lead {
+  margin: 0 auto;
+  max-width: 640px;
+  font-size: clamp(1.05rem, 2.5vw, 1.25rem);
+  line-height: 1.7;
+  color: rgba(255, 228, 206, 0.85);
+}
+
+.vision {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.vision__panel {
+  background: linear-gradient(160deg, rgba(33, 33, 33, 0.9), rgba(12, 12, 12, 0.95));
+  border-radius: 20px;
+  border: 1px solid rgba(255, 120, 40, 0.35);
+  padding: 1.75rem;
+  box-shadow: inset 0 0 30px rgba(255, 120, 40, 0.08);
+}
+
+.vision__panel h2 {
+  margin-top: 0;
+  color: #ffb577;
+}
+
+.vision__panel p {
+  margin-bottom: 0;
+  line-height: 1.6;
+  color: rgba(255, 235, 220, 0.78);
+}
+
+.widget-highlight {
+  display: flex;
+  justify-content: center;
+}
+
+.widget-card {
+  position: relative;
+  max-width: 420px;
+  width: 100%;
+  background: linear-gradient(150deg, rgba(255, 120, 40, 0.12), rgba(12, 12, 12, 0.92));
+  border-radius: 24px;
+  padding: 2.25rem clamp(1.5rem, 3vw, 2.75rem);
+  border: 1px solid rgba(255, 140, 66, 0.45);
+  box-shadow:
+    0 25px 55px rgba(0, 0, 0, 0.55),
+    inset 0 0 40px rgba(255, 120, 40, 0.14);
+  text-align: center;
+}
+
+.widget-card__tag {
+  position: absolute;
+  top: -14px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: linear-gradient(120deg, #ff8f4b, #ff6f32);
+  color: #130a05;
+  font-size: 0.75rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  padding: 0.35rem 1.25rem;
+  border-radius: 999px;
+  box-shadow: 0 10px 30px rgba(255, 120, 40, 0.45);
+}
+
+.widget-card__title {
+  margin: 0.75rem 0 0.5rem;
+  font-size: clamp(1.6rem, 3vw, 2rem);
+  color: #ffe3ca;
+}
+
+.widget-card__description {
+  margin: 0 auto 1.75rem;
+  line-height: 1.6;
+  max-width: 320px;
+  color: rgba(255, 230, 210, 0.8);
+}
+
+.widget-card__action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  padding: 0.85rem 1.85rem;
+  border-radius: 999px;
+  background: linear-gradient(120deg, #ff8f4b, #ff6f32);
+  color: #150904;
+  text-decoration: none;
+  box-shadow: 0 15px 35px rgba(255, 120, 40, 0.45);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.widget-card__action:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 45px rgba(255, 120, 40, 0.5);
+}
+
+.roadmap {
+  background: linear-gradient(140deg, rgba(28, 28, 28, 0.9), rgba(8, 8, 8, 0.92));
+  border-radius: 20px;
+  border: 1px solid rgba(255, 120, 40, 0.3);
+  padding: 1.75rem;
+}
+
+.roadmap h4 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(255, 165, 102, 0.8);
+}
+
+.roadmap ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: rgba(255, 235, 220, 0.78);
+  line-height: 1.7;
+}
+
+.mini-game {
+  min-height: 100dvh;
+  display: grid;
+  place-items: center;
+  padding: clamp(2rem, 6vw, 4rem);
+  background:
+    radial-gradient(100% 100% at 50% 0%, rgba(255, 109, 36, 0.18), transparent 60%),
+    linear-gradient(180deg, #0c0c0c 0%, #050505 70%);
+}
+
+.game-card {
+  max-width: 520px;
+  width: min(520px, 100%);
+  background: linear-gradient(150deg, rgba(33, 33, 33, 0.96), rgba(8, 8, 8, 0.92));
+  border-radius: 28px;
+  border: 1px solid rgba(255, 140, 66, 0.4);
+  box-shadow:
+    0 25px 60px rgba(0, 0, 0, 0.55),
+    inset 0 0 45px rgba(255, 120, 40, 0.1);
+  padding: clamp(2rem, 4vw, 3rem);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.game-card h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 2.6rem);
+  text-align: center;
+  color: #ffe3ca;
+}
+
+.game-card p {
+  margin: 0;
+  line-height: 1.6;
+  color: rgba(255, 230, 210, 0.85);
+}
+
+.guess-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.guess-form label {
+  font-size: 0.95rem;
+  color: rgba(255, 200, 170, 0.78);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.guess-form input[type='number'] {
+  border: none;
+  border-radius: 14px;
+  padding: 0.9rem 1rem;
+  background: rgba(255, 255, 255, 0.05);
+  color: #ffeede;
+  font-size: 1.1rem;
+}
+
+.guess-form input[type='number']:focus {
+  outline: 2px solid rgba(255, 140, 66, 0.6);
+  outline-offset: 3px;
+}
+
+.guess-form button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: linear-gradient(120deg, #ff8f4b, #ff6f32);
+  color: #150904;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 18px 35px rgba(255, 120, 40, 0.45);
+}
+
+.guess-form button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 40px rgba(255, 120, 40, 0.55);
+}
+
+.game-feedback {
+  font-size: 1.05rem;
+  text-align: center;
+  min-height: 1.4em;
+  color: #ffbc80;
+}
+
+.game-stats {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.95rem;
+  color: rgba(255, 228, 206, 0.7);
+}
+
+.back-link {
+  justify-self: center;
+  color: rgba(255, 210, 180, 0.85);
+  text-decoration: none;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+}
+
+.back-link:hover {
+  color: #ffd1a6;
+}
+
+@media (max-width: 768px) {
+  .welcome-page {
+    padding: 4rem 1.5rem;
+  }
+
+  .zipper-strip {
+    left: 15%;
+    right: 15%;
+  }
+
+  .vision {
+    grid-template-columns: 1fr;
+  }
+
+  .game-stats {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+}

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,13 +1,15 @@
+import './globals.css';
+
 export const metadata = {
-  title: 'Bienvenido | Next.js + GitHub Pages',
-  description: 'Landing mínima de Next.js exportada a GitHub Pages'
+  title: 'Rodrigoplk repo',
+  description: 'Laboratorio de utilidades y minijuegos personales de Rodrigoplk',
 };
 
 export default function RootLayout({ children }) {
   return (
     <html lang="es">
       <head />
-      <body>
+      <body className="theme-body">
         {children}
       </body>
     </html>

--- a/app/page.js
+++ b/app/page.js
@@ -1,38 +1,55 @@
 export default function HomePage() {
   return (
-    <main style={{
-      minHeight: '100dvh',
-      display: 'grid',
-      placeItems: 'center',
-      padding: '2rem',
-      fontFamily: 'system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, "Helvetica Neue", Arial, "Apple Color Emoji","Segoe UI Emoji"'
-    }}>
-      <section style={{
-        maxWidth: 760,
-        width: '100%',
-        borderRadius: 16,
-        padding: '2.5rem',
-        boxShadow: '0 10px 35px rgba(0,0,0,.08)',
-        textAlign: 'center'
-      }}>
-        <h1 style={{ fontSize: 'clamp(2rem, 4vw, 3rem)', margin: 0 }}>
-          ¡Bienvenido a tu página Next.js!
-        </h1>
-        <p style={{ fontSize: '1.1rem', lineHeight: 1.6, marginTop: '1rem', opacity: .85 }}>
-          Esta landing está lista para desplegarse en <strong>GitHub Pages</strong> usando <em>GitHub Actions</em>, sin servidor y sin coste.
-        </p>
+    <main className="welcome-page">
+      <span className="zipper-strip top" aria-hidden="true" />
+      <span className="zipper-strip bottom" aria-hidden="true" />
 
-        <div style={{ display: 'grid', gap: '.75rem', marginTop: '2rem' }}>
-          <a href="https://nextjs.org/docs" target="_blank" rel="noreferrer"
-             style={{ textDecoration: 'none' }}>
-            📘 Documentación de Next.js
-          </a>
-          <a href="https://docs.github.com/en/pages" target="_blank" rel="noreferrer"
-             style={{ textDecoration: 'none' }}>
-            🐙 Guía de GitHub Pages
-          </a>
-        </div>
-      </section>
+      <div className="zipper-frame">
+        <header className="hero">
+          <p className="hero__subtitle">Laboratorio personal</p>
+          <h1 className="hero__title">Rodrigoplk repo</h1>
+          <p className="hero__lead">
+            Un espacio vivo para experimentar con widgets, utilidades instantáneas y minijuegos que van apareciendo cuando la inspiración golpea.
+          </p>
+        </header>
+
+        <section className="vision">
+          <div className="vision__panel">
+            <h2>Ideas en iteración</h2>
+            <p>
+              El objetivo es construir un set de herramientas rápidas para el día a día: desde cronómetros personalizados hasta tableros lúdicos.
+            </p>
+          </div>
+          <div className="vision__panel">
+            <h2>Estética modular</h2>
+            <p>
+              Cada módulo tendrá su propia personalidad, manteniendo el hilo visual oscuro con destellos naranjas y bordes suaves.
+            </p>
+          </div>
+        </section>
+
+        <section className="widget-highlight">
+          <article className="widget-card">
+            <span className="widget-card__tag">Widget destacado</span>
+            <h3 className="widget-card__title">Adivina el número</h3>
+            <p className="widget-card__description">
+              Un pequeño desafío de intuición para calentar la mente: intenta adivinar el número secreto entre 1 y 50 en los menores intentos posibles.
+            </p>
+            <a className="widget-card__action" href="/widgets/adivina">
+              Entrar al minijuego
+            </a>
+          </article>
+        </section>
+
+        <footer className="roadmap">
+          <h4>En la hoja de ruta:</h4>
+          <ul>
+            <li>Widgets de productividad en vivo.</li>
+            <li>Mini retos que se resuelven en 2 minutos.</li>
+            <li>Integraciones con APIs curiosas.</li>
+          </ul>
+        </footer>
+      </div>
     </main>
   );
 }

--- a/app/widgets/adivina/GuessNumberGame.js
+++ b/app/widgets/adivina/GuessNumberGame.js
@@ -1,0 +1,140 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+const MIN_VALUE = 1;
+const MAX_VALUE = 50;
+
+const generateSecret = () =>
+  Math.floor(Math.random() * (MAX_VALUE - MIN_VALUE + 1)) + MIN_VALUE;
+
+export default function GuessNumberGame() {
+  const [secret, setSecret] = useState(generateSecret);
+  const [guess, setGuess] = useState('');
+  const [attempts, setAttempts] = useState(0);
+  const [roundsCleared, setRoundsCleared] = useState(0);
+  const [bestScore, setBestScore] = useState(null);
+  const [feedback, setFeedback] = useState(
+    'He generado un número secreto entre 1 y 50. ¡Haz tu primer intento!'
+  );
+
+  const hintText = useMemo(
+    () => `Introduce un número entre ${MIN_VALUE} y ${MAX_VALUE}.`,
+    []
+  );
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+
+    if (guess.trim() === '') {
+      setFeedback('Escribe un número antes de enviar tu intento.');
+      return;
+    }
+
+    const numericGuess = Number(guess);
+
+    if (!Number.isInteger(numericGuess)) {
+      setFeedback('Solo se aceptan números enteros.');
+      return;
+    }
+
+    if (numericGuess < MIN_VALUE || numericGuess > MAX_VALUE) {
+      setFeedback(`Recuerda que debe estar entre ${MIN_VALUE} y ${MAX_VALUE}.`);
+      return;
+    }
+
+    const attemptsSoFar = attempts + 1;
+
+    if (numericGuess === secret) {
+      const nextSecret = generateSecret();
+      const nextBest =
+        bestScore === null ? attemptsSoFar : Math.min(bestScore, attemptsSoFar);
+
+      setFeedback(
+        `🎯 ¡Acertaste en ${attemptsSoFar} intento${
+          attemptsSoFar === 1 ? '' : 's'
+        }! He generado otro número para que sigas practicando.`
+      );
+      setBestScore(nextBest);
+      setRoundsCleared((value) => value + 1);
+      setSecret(nextSecret);
+      setAttempts(0);
+    } else if (numericGuess < secret) {
+      setFeedback('⬆️ Pista: el número secreto es más alto.');
+      setAttempts(attemptsSoFar);
+    } else {
+      setFeedback('⬇️ Pista: necesitas un número más bajo.');
+      setAttempts(attemptsSoFar);
+    }
+
+    setGuess('');
+  };
+
+  return (
+    <main className="mini-game">
+      <div className="game-card">
+        <h1>Minijuego · Adivina el número</h1>
+        <p>
+          Tienes un número secreto en mente entre {MIN_VALUE} y {MAX_VALUE}. Usa las
+          pistas después de cada intento para reducir posibilidades.
+        </p>
+
+        <form className="guess-form" onSubmit={handleSubmit}>
+          <label htmlFor="guess-input">Tu intento</label>
+          <input
+            id="guess-input"
+            type="number"
+            inputMode="numeric"
+            min={MIN_VALUE}
+            max={MAX_VALUE}
+            placeholder={`${MIN_VALUE} - ${MAX_VALUE}`}
+            value={guess}
+            onChange={(event) => setGuess(event.target.value)}
+            aria-describedby="guess-hint"
+          />
+          <span
+            id="guess-hint"
+            style={{ fontSize: '0.85rem', color: 'rgba(255, 228, 206, 0.65)' }}
+          >
+            {hintText}
+          </span>
+          <button type="submit">Probar suerte</button>
+        </form>
+
+        <div className="game-feedback" role="status" aria-live="polite">
+          {feedback}
+        </div>
+
+        <div className="game-stats">
+          <span>Intentos en esta ronda: {attempts}</span>
+          <span>
+            Mejor marca:{' '}
+            {bestScore === null
+              ? '—'
+              : `${bestScore} intento${bestScore === 1 ? '' : 's'}`}
+          </span>
+        </div>
+        <div className="game-stats">
+          <span>Rondas superadas: {roundsCleared}</span>
+          <button
+            type="button"
+            className="back-link"
+            onClick={() => {
+              setSecret(generateSecret());
+              setAttempts(0);
+              setRoundsCleared(0);
+              setBestScore(null);
+              setFeedback('Marcadores reiniciados. ¡Nuevo número listo!');
+            }}
+          >
+            Reiniciar marcadores
+          </button>
+        </div>
+
+        <a className="back-link" href="/">
+          Volver a la base
+        </a>
+      </div>
+    </main>
+  );
+}

--- a/app/widgets/adivina/page.js
+++ b/app/widgets/adivina/page.js
@@ -1,0 +1,11 @@
+import GuessNumberGame from './GuessNumberGame';
+
+export const metadata = {
+  title: 'Adivina el número | Rodrigoplk repo',
+  description:
+    'Minijuego mental para adivinar un número secreto entre 1 y 50 dentro del laboratorio de Rodrigoplk.',
+};
+
+export default function Page() {
+  return <GuessNumberGame />;
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,3 @@
 module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
+  plugins: {},
 }


### PR DESCRIPTION
## Summary
- redesign the landing page with a dark/orange interface, zipper frame accents, and widget highlight
- add global styles to support the new aesthetic and reusable components for the homepage and widgets
- create an "Adivina el número" minigame route with client logic and simplify the PostCSS config for the build

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d50c9ce96083219258f00cc39409f7