### PR TITLE
Simplify landing content and fix widget link

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -1,54 +1,25 @@
+import Link from "next/link";
+
 export default function HomePage() {
   return (
     <main className="welcome-page">
-      <span className="zipper-strip top" aria-hidden="true" />
-      <span className="zipper-strip bottom" aria-hidden="true" />
-
       <div className="zipper-frame">
         <header className="hero">
-          <p className="hero__subtitle">Laboratorio personal</p>
-          <h1 className="hero__title">Rodrigoplk repo</h1>
-          <p className="hero__lead">
-            Un espacio vivo para experimentar con widgets, utilidades instantáneas y minijuegos que van apareciendo cuando la inspiración golpea.
-          </p>
+          <h1 className="hero__title">Rodrigoplk playground</h1>
         </header>
-
-        <section className="vision">
-          <div className="vision__panel">
-            <h2>Ideas en iteración</h2>
-            <p>
-              El objetivo es construir un set de herramientas rápidas para el día a día: desde cronómetros personalizados hasta tableros lúdicos.
-            </p>
-          </div>
-          <div className="vision__panel">
-            <h2>Estética modular</h2>
-            <p>
-              Cada módulo tendrá su propia personalidad, manteniendo el hilo visual oscuro con destellos naranjas y bordes suaves.
-            </p>
-          </div>
-        </section>
 
         <section className="widget-highlight">
           <article className="widget-card">
-            <span className="widget-card__tag">Widget destacado</span>
-            <h3 className="widget-card__title">Adivina el número</h3>
+            <span className="widget-card__tag">Adivina el número</span>
+            <h3 className="widget-card__title">Pon a prueba tu intuición</h3>
             <p className="widget-card__description">
-              Un pequeño desafío de intuición para calentar la mente: intenta adivinar el número secreto entre 1 y 50 en los menores intentos posibles.
+              Un minijuego rápido para descubrir el número secreto entre 1 y 50.
             </p>
-            <a className="widget-card__action" href="/widgets/adivina">
+            <Link className="widget-card__action" href="/widgets/adivina">
               Entrar al minijuego
-            </a>
+            </Link>
           </article>
         </section>
-
-        <footer className="roadmap">
-          <h4>En la hoja de ruta:</h4>
-          <ul>
-            <li>Widgets de productividad en vivo.</li>
-            <li>Mini retos que se resuelven en 2 minutos.</li>
-            <li>Integraciones con APIs curiosas.</li>
-          </ul>
-        </footer>
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- strip ancillary hero panels and roadmap to focus on the featured widget
- rename the space to “Rodrigoplk playground” and simplify the hero copy
- update the featured card copy, tag text, and link to use Next.js Link for the adivina widget

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d52273143483218a4c839f5cdc835c