### PR TITLE
Add sudoku validator widget

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -173,6 +173,8 @@ a:hover {
 .widget-highlight {
   display: flex;
   justify-content: center;
+  flex-wrap: wrap;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
 }
 
 .widget-card {
@@ -377,6 +379,149 @@ a:hover {
   color: #ffd1a6;
 }
 
+.puzzle-card {
+  max-width: 720px;
+  width: min(720px, 100%);
+  background: linear-gradient(150deg, rgba(33, 33, 33, 0.96), rgba(8, 8, 8, 0.92));
+  border-radius: 28px;
+  border: 1px solid rgba(255, 140, 66, 0.4);
+  box-shadow:
+    0 25px 60px rgba(0, 0, 0, 0.55),
+    inset 0 0 45px rgba(255, 120, 40, 0.1);
+  padding: clamp(2rem, 4vw, 3.25rem);
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.25rem);
+}
+
+.puzzle-card__header {
+  display: grid;
+  gap: 0.75rem;
+  text-align: center;
+}
+
+.puzzle-card__tag {
+  justify-self: center;
+  padding: 0.4rem 1.5rem;
+  border-radius: 999px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  background: linear-gradient(120deg, #ff8f4b, #ff6f32);
+  color: #130a05;
+  box-shadow: 0 12px 28px rgba(255, 120, 40, 0.45);
+}
+
+.puzzle-card__header h1 {
+  margin: 0;
+  font-size: clamp(2.2rem, 4vw, 2.8rem);
+  color: #ffe3ca;
+}
+
+.puzzle-card__header p {
+  margin: 0;
+  line-height: 1.7;
+  color: rgba(255, 230, 210, 0.85);
+}
+
+.sudoku-grid {
+  display: grid;
+  gap: 0.4rem;
+  background: rgba(255, 255, 255, 0.04);
+  padding: clamp(0.9rem, 2vw, 1.25rem);
+  border-radius: 20px;
+  border: 1px solid rgba(255, 140, 66, 0.28);
+  box-shadow: inset 0 0 25px rgba(255, 120, 40, 0.12);
+}
+
+.sudoku-grid__row {
+  display: grid;
+  grid-template-columns: repeat(9, 1fr);
+  gap: 0.4rem;
+}
+
+.sudoku-cell {
+  position: relative;
+  border-radius: 12px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 140, 66, 0.18);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.sudoku-cell input {
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  border: none;
+  background: transparent;
+  color: #ffeede;
+  font-size: clamp(1.1rem, 2.5vw, 1.4rem);
+  text-align: center;
+  font-weight: 600;
+}
+
+.sudoku-cell input:focus {
+  outline: none;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.sudoku-cell--divider-right {
+  border-right: 3px solid rgba(255, 140, 66, 0.6);
+}
+
+.sudoku-cell--divider-bottom {
+  border-bottom: 3px solid rgba(255, 140, 66, 0.6);
+}
+
+.sudoku-cell--error {
+  border-color: rgba(255, 100, 100, 0.75);
+  box-shadow: 0 0 12px rgba(255, 90, 90, 0.4);
+}
+
+.sudoku-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.sudoku-actions button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.9rem 1.9rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  box-shadow: 0 18px 35px rgba(255, 120, 40, 0.45);
+  background: linear-gradient(120deg, #ff8f4b, #ff6f32);
+  color: #150904;
+}
+
+.sudoku-actions button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 40px rgba(255, 120, 40, 0.55);
+}
+
+.sudoku-actions__secondary {
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 220, 190, 0.9);
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.4);
+}
+
+.sudoku-actions__secondary:hover {
+  background: rgba(255, 255, 255, 0.12);
+  box-shadow: 0 15px 32px rgba(0, 0, 0, 0.45);
+}
+
+.sudoku-status {
+  margin: 0;
+  text-align: center;
+  color: #ffbc80;
+  font-size: 1rem;
+  min-height: 1.4em;
+}
+
 @media (max-width: 768px) {
   .welcome-page {
     padding: 4rem 1.5rem;
@@ -394,5 +539,13 @@ a:hover {
   .game-stats {
     flex-direction: column;
     gap: 0.5rem;
+  }
+
+  .sudoku-grid {
+    gap: 0.3rem;
+  }
+
+  .sudoku-grid__row {
+    gap: 0.3rem;
   }
 }

--- a/app/page.js
+++ b/app/page.js
@@ -19,6 +19,17 @@ export default function HomePage() {
               Entrar al minijuego
             </Link>
           </article>
+
+          <article className="widget-card">
+            <span className="widget-card__tag">Sudoku toolkit</span>
+            <h3 className="widget-card__title">Comprueba tus retículas</h3>
+            <p className="widget-card__description">
+              Construye un tablero desde cero y verifica si respeta las reglas y se puede resolver.
+            </p>
+            <Link className="widget-card__action" href="/widgets/validador">
+              Validar un sudoku
+            </Link>
+          </article>
         </section>
       </div>
     </main>

--- a/app/widgets/validador/SudokuValidator.js
+++ b/app/widgets/validador/SudokuValidator.js
@@ -1,0 +1,225 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+const GRID_SIZE = 9;
+
+const createEmptyGrid = () =>
+  Array.from({ length: GRID_SIZE }, () => Array.from({ length: GRID_SIZE }, () => ''));
+
+const toKey = (row, col) => `${row}-${col}`;
+
+const isPlacementSafe = (board, row, col, value) => {
+  for (let i = 0; i < GRID_SIZE; i += 1) {
+    if (board[row][i] === value || board[i][col] === value) {
+      return false;
+    }
+  }
+
+  const subgridRow = Math.floor(row / 3) * 3;
+  const subgridCol = Math.floor(col / 3) * 3;
+
+  for (let r = subgridRow; r < subgridRow + 3; r += 1) {
+    for (let c = subgridCol; c < subgridCol + 3; c += 1) {
+      if (board[r][c] === value) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+};
+
+const solveSudoku = (board) => {
+  for (let row = 0; row < GRID_SIZE; row += 1) {
+    for (let col = 0; col < GRID_SIZE; col += 1) {
+      if (board[row][col] === 0) {
+        for (let value = 1; value <= GRID_SIZE; value += 1) {
+          if (isPlacementSafe(board, row, col, value)) {
+            board[row][col] = value;
+
+            if (solveSudoku(board)) {
+              return true;
+            }
+
+            board[row][col] = 0;
+          }
+        }
+
+        board[row][col] = 0;
+        return false;
+      }
+    }
+  }
+
+  return true;
+};
+
+export default function SudokuValidator() {
+  const [grid, setGrid] = useState(createEmptyGrid);
+  const [statusMessage, setStatusMessage] = useState(
+    'Propón un sudoku rellenando las casillas que quieras y comprueba si es válido.'
+  );
+  const [invalidCells, setInvalidCells] = useState([]);
+
+  const invalidCellSet = useMemo(() => new Set(invalidCells), [invalidCells]);
+
+  const handleCellChange = (rowIndex, colIndex, value) => {
+    const sanitized = value.replace(/[^1-9]/g, '').slice(0, 1);
+
+    setGrid((previous) => {
+      const next = previous.map((row) => row.slice());
+      next[rowIndex][colIndex] = sanitized;
+      return next;
+    });
+  };
+
+  const clearGrid = () => {
+    setGrid(createEmptyGrid());
+    setInvalidCells([]);
+    setStatusMessage('Tablero reiniciado. ¡Listo para un nuevo intento!');
+  };
+
+  const validateSudoku = () => {
+    const numericBoard = grid.map((row) =>
+      row.map((cell) => {
+        if (cell === '') {
+          return 0;
+        }
+
+        const numericValue = Number(cell);
+
+        if (Number.isNaN(numericValue) || numericValue < 1 || numericValue > 9) {
+          return NaN;
+        }
+
+        return numericValue;
+      })
+    );
+
+    let hasInvalid = false;
+    const conflicts = [];
+
+    for (let row = 0; row < GRID_SIZE; row += 1) {
+      for (let col = 0; col < GRID_SIZE; col += 1) {
+        const value = numericBoard[row][col];
+
+        if (Number.isNaN(value)) {
+          conflicts.push(toKey(row, col));
+          hasInvalid = true;
+          continue;
+        }
+
+        if (value === 0) {
+          continue;
+        }
+
+        numericBoard[row][col] = 0;
+
+        if (!isPlacementSafe(numericBoard, row, col, value)) {
+          conflicts.push(toKey(row, col));
+          hasInvalid = true;
+        }
+
+        numericBoard[row][col] = value;
+      }
+    }
+
+    if (hasInvalid) {
+      setInvalidCells(conflicts);
+      if (conflicts.length > 0) {
+        const [firstConflict] = conflicts;
+        const [rowIndex, colIndex] = firstConflict
+          .split('-')
+          .map((part) => Number(part) + 1);
+        setStatusMessage(
+          `Hay conflictos en el tablero. Revisa la fila ${rowIndex} columna ${colIndex}.`
+        );
+      } else {
+        setStatusMessage('Hay conflictos en el tablero. Revisa las casillas destacadas.');
+      }
+      return;
+    }
+
+    const boardForSolving = numericBoard.map((row) => row.slice());
+
+    const canBeSolved = solveSudoku(boardForSolving);
+
+    if (canBeSolved) {
+      setInvalidCells([]);
+      setStatusMessage('✅ El sudoku es válido y tiene al menos una solución.');
+    } else {
+      setInvalidCells([]);
+      setStatusMessage('⚠️ El sudoku no se puede resolver sin romper las reglas.');
+    }
+  };
+
+  return (
+    <main className="mini-game">
+      <div className="puzzle-card">
+        <header className="puzzle-card__header">
+          <span className="puzzle-card__tag">Laboratorio lógico</span>
+          <h1>Validador de sudokus</h1>
+          <p>
+            Comprueba si tu propuesta respeta las reglas clásicas: sin duplicados en filas,
+            columnas ni regiones, y con al menos una solución posible.
+          </p>
+        </header>
+
+        <div className="sudoku-grid" role="group" aria-label="Tablero de sudoku editable">
+          {grid.map((row, rowIndex) => (
+            <div key={`row-${rowIndex}`} className="sudoku-grid__row">
+              {row.map((value, colIndex) => {
+                const cellKey = toKey(rowIndex, colIndex);
+                const cellClasses = ['sudoku-cell'];
+
+                if (invalidCellSet.has(cellKey)) {
+                  cellClasses.push('sudoku-cell--error');
+                }
+
+                if (colIndex === 2 || colIndex === 5) {
+                  cellClasses.push('sudoku-cell--divider-right');
+                }
+
+                if (rowIndex === 2 || rowIndex === 5) {
+                  cellClasses.push('sudoku-cell--divider-bottom');
+                }
+
+                return (
+                  <div key={cellKey} className={cellClasses.join(' ')}>
+                    <input
+                      value={value}
+                      onChange={(event) =>
+                        handleCellChange(rowIndex, colIndex, event.target.value)
+                      }
+                      inputMode="numeric"
+                      maxLength={1}
+                      aria-label={`Fila ${rowIndex + 1}, columna ${colIndex + 1}`}
+                    />
+                  </div>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+
+        <div className="sudoku-actions">
+          <button type="button" onClick={validateSudoku}>
+            Validar sudoku
+          </button>
+          <button type="button" onClick={clearGrid} className="sudoku-actions__secondary">
+            Limpiar tablero
+          </button>
+        </div>
+
+        <p className="sudoku-status" role="status" aria-live="polite">
+          {statusMessage}
+        </p>
+
+        <a className="back-link" href="/">
+          Volver a la base
+        </a>
+      </div>
+    </main>
+  );
+}

--- a/app/widgets/validador/page.js
+++ b/app/widgets/validador/page.js
@@ -1,0 +1,11 @@
+import SudokuValidator from './SudokuValidator';
+
+export const metadata = {
+  title: 'Validador de sudokus | Rodrigoplk repo',
+  description:
+    'Introduce tus números y valida al instante si un tablero de sudoku es coherente y resoluble.',
+};
+
+export default function Page() {
+  return <SudokuValidator />;
+}


### PR DESCRIPTION
## Summary
- add an interactive sudoku validator widget with solvability checks and conflict highlights
- extend the landing page hero to showcase the new sudoku tool alongside the guessing game
- style the sudoku interface to match the site's neon-dark aesthetic

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d52d659fa4832196116b51d8c73157