### PR TITLE
Add Easter egg to guess widget and fix base links

### DIFF
--- a/app/widgets/adivina/GuessNumberGame.js
+++ b/app/widgets/adivina/GuessNumberGame.js
@@ -70,6 +70,8 @@ export default function GuessNumberGame() {
     setGuess('');
   };
 
+  const showSergioEasterEgg = guess.trim() === '23';
+
   return (
     <main className="mini-game">
       <div className="game-card">
@@ -98,6 +100,17 @@ export default function GuessNumberGame() {
           >
             {hintText}
           </span>
+          {showSergioEasterEgg ? (
+            <p
+              style={{
+                marginTop: '0.35rem',
+                fontSize: '0.8rem',
+                color: 'rgba(200, 200, 200, 0.6)',
+              }}
+            >
+              23.. Sergio? 🤔
+            </p>
+          ) : null}
           <button type="submit">Probar suerte</button>
         </form>
 
@@ -131,7 +144,7 @@ export default function GuessNumberGame() {
           </button>
         </div>
 
-        <a className="back-link" href="/">
+        <a className="back-link" href="/frontiers">
           Volver a la base
         </a>
       </div>

--- a/app/widgets/validador/SudokuValidator.js
+++ b/app/widgets/validador/SudokuValidator.js
@@ -267,7 +267,7 @@ export default function SudokuValidator() {
           {statusMessage}
         </p>
 
-        <a className="back-link" href="/">
+        <a className="back-link" href="/frontiers">
           Volver a la base
         </a>
       </div>


### PR DESCRIPTION
## Summary
- show a subtle "23.. Sergio? 🤔" easter egg when the guess input is 23 and hide it otherwise
- update the "Volver a la base" links so they point to /frontiers for both widgets

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d559c8a1348321bddad50e2ad90d44