### PR TITLE
Add play button after successful sudoku validation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -514,6 +514,29 @@ a:hover {
   box-shadow: 0 15px 32px rgba(0, 0, 0, 0.45);
 }
 
+.sudoku-play-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin: 1.2rem auto 0;
+  padding: 0.85rem 2.4rem;
+  border-radius: 999px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-decoration: none;
+  background: linear-gradient(120deg, #34d399, #059669);
+  color: #042015;
+  box-shadow: 0 18px 35px rgba(56, 189, 148, 0.45);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.sudoku-play-link:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 42px rgba(16, 185, 129, 0.55);
+  background: linear-gradient(120deg, #4ade80, #10b981);
+}
+
 .sudoku-status {
   margin: 0;
   text-align: center;

--- a/app/widgets/validador/SudokuValidator.js
+++ b/app/widgets/validador/SudokuValidator.js
@@ -3,6 +3,7 @@
 import { useMemo, useState } from 'react';
 
 const GRID_SIZE = 9;
+const PLAY_SUDOKU_BASE_URL = 'https://rodrigoplk.github.io/frontiers/widgets/sudoku';
 
 const createEmptyGrid = () =>
   Array.from({ length: GRID_SIZE }, () => Array.from({ length: GRID_SIZE }, () => ''));
@@ -103,12 +104,18 @@ const countSolutions = (board, limit = 2) => {
   return totalSolutions;
 };
 
+const serializeBoardForPlay = (board) =>
+  board
+    .map((row) => row.map((value) => (value === 0 ? '0' : String(value))).join(''))
+    .join('');
+
 export default function SudokuValidator() {
   const [grid, setGrid] = useState(createEmptyGrid);
   const [statusMessage, setStatusMessage] = useState(
     'Propón un sudoku rellenando las casillas que quieras y comprueba si es válido y único.'
   );
   const [invalidCells, setInvalidCells] = useState([]);
+  const [playUrl, setPlayUrl] = useState(null);
 
   const invalidCellSet = useMemo(() => new Set(invalidCells), [invalidCells]);
 
@@ -120,12 +127,14 @@ export default function SudokuValidator() {
       next[rowIndex][colIndex] = sanitized;
       return next;
     });
+    setPlayUrl(null);
   };
 
   const clearGrid = () => {
     setGrid(createEmptyGrid());
     setInvalidCells([]);
     setStatusMessage('Tablero reiniciado. ¡Listo para un nuevo intento!');
+    setPlayUrl(null);
   };
 
   const validateSudoku = () => {
@@ -186,6 +195,7 @@ export default function SudokuValidator() {
       } else {
         setStatusMessage('Hay conflictos en el tablero. Revisa las casillas destacadas.');
       }
+      setPlayUrl(null);
       return;
     }
 
@@ -196,12 +206,17 @@ export default function SudokuValidator() {
     if (solutionCount === 1) {
       setInvalidCells([]);
       setStatusMessage('✅ El sudoku es válido y tiene una única solución.');
+      const url = new URL(PLAY_SUDOKU_BASE_URL);
+      url.searchParams.set('board', serializeBoardForPlay(numericBoard));
+      setPlayUrl(url.toString());
     } else if (solutionCount === 0) {
       setInvalidCells([]);
       setStatusMessage('⚠️ El sudoku no se puede resolver sin romper las reglas.');
+      setPlayUrl(null);
     } else {
       setInvalidCells([]);
       setStatusMessage('ℹ️ El sudoku es resoluble, pero tiene múltiples soluciones.');
+      setPlayUrl(null);
     }
   };
 
@@ -262,6 +277,17 @@ export default function SudokuValidator() {
             Limpiar tablero
           </button>
         </div>
+
+        {playUrl && (
+          <a
+            className="sudoku-play-link"
+            href={playUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Jugar este sudoku
+          </a>
+        )}
 
         <p className="sudoku-status" role="status" aria-live="polite">
           {statusMessage}


### PR DESCRIPTION
## Summary
- serialize the validated sudoku board and track a shareable play URL once it has a unique solution
- reset and hide the play link whenever the grid changes or fails validation to avoid stale data
- expose a green “Jugar este sudoku” button beneath the actions that opens the generated puzzle URL with dedicated styling

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d57b71f12c8321885e54237293b0a5