### PR TITLE
Show play link when sudoku is solvable

### DIFF
--- a/app/widgets/validador/SudokuValidator.js
+++ b/app/widgets/validador/SudokuValidator.js
@@ -203,21 +203,23 @@ export default function SudokuValidator() {
 
     const solutionCount = countSolutions(boardForSolving, 2);
 
-    if (solutionCount === 1) {
-      setInvalidCells([]);
-      setStatusMessage('✅ El sudoku es válido y tiene una única solución.');
-      const url = new URL(PLAY_SUDOKU_BASE_URL);
-      url.searchParams.set('board', serializeBoardForPlay(numericBoard));
-      setPlayUrl(url.toString());
-    } else if (solutionCount === 0) {
+    if (solutionCount === 0) {
       setInvalidCells([]);
       setStatusMessage('⚠️ El sudoku no se puede resolver sin romper las reglas.');
       setPlayUrl(null);
-    } else {
-      setInvalidCells([]);
-      setStatusMessage('ℹ️ El sudoku es resoluble, pero tiene múltiples soluciones.');
-      setPlayUrl(null);
+      return;
     }
+
+    setInvalidCells([]);
+    if (solutionCount === 1) {
+      setStatusMessage('✅ El sudoku es válido y tiene una única solución.');
+    } else {
+      setStatusMessage('ℹ️ El sudoku es resoluble, pero tiene múltiples soluciones.');
+    }
+
+    const url = new URL(PLAY_SUDOKU_BASE_URL);
+    url.searchParams.set('board', serializeBoardForPlay(numericBoard));
+    setPlayUrl(url.toString());
   };
 
   return (


### PR DESCRIPTION
## Summary
- ensure the validator keeps the sudoku play link available for any solvable grid, not just those with a unique solution
- continue hiding the link when the board has conflicts or no valid solutions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5b0e130dc8321aa43acff8e6beea9