### PR TITLE
Wrap sudoku widget in suspense boundary

### DIFF
--- a/app/widgets/sudoku/page.js
+++ b/app/widgets/sudoku/page.js
@@ -1,3 +1,5 @@
+import { Suspense } from 'react';
+
 import SudokuPlayer from './SudokuPlayer';
 
 export const metadata = {
@@ -7,5 +9,21 @@ export const metadata = {
 };
 
 export default function Page() {
-  return <SudokuPlayer />;
+  return (
+    <Suspense
+      fallback={
+        <main className="mini-game">
+          <div className="puzzle-card">
+            <header className="puzzle-card__header">
+              <span className="puzzle-card__tag">Modo juego</span>
+              <h1>Jugar sudoku</h1>
+              <p>Preparando el tablero…</p>
+            </header>
+          </div>
+        </main>
+      }
+    >
+      <SudokuPlayer />
+    </Suspense>
+  );
 }


### PR DESCRIPTION
## Summary
- wrap the sudoku widget page in a Suspense boundary with a themed fallback
- ensure useSearchParams runs within a suspense boundary to satisfy Next.js build requirements

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d62e7cf6e4832185da70e662dc5f05