### PR TITLE
Adjust widget card responsiveness

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -189,7 +189,8 @@ a:hover {
   width: 100%;
   background: linear-gradient(150deg, rgba(255, 120, 40, 0.12), rgba(12, 12, 12, 0.92));
   border-radius: 24px;
-  padding: 2.25rem clamp(1.5rem, 3vw, 2.75rem);
+  padding: clamp(1.65rem, 1.35rem + 1.2vw, 2.25rem)
+    clamp(1.3rem, 0.95rem + 1.4vw, 2.75rem);
   border: 1px solid rgba(255, 140, 66, 0.45);
   box-shadow:
     0 25px 55px rgba(0, 0, 0, 0.55),
@@ -200,28 +201,30 @@ a:hover {
   flex-direction: column;
   justify-content: flex-start;
   align-items: center;
-  gap: 1.25rem;
-  overflow: hidden;
+  gap: clamp(0.9rem, 0.45rem + 1vw, 1.25rem);
+  overflow: visible;
+  font-size: clamp(0.88rem, 0.78rem + 0.45vw, 1rem);
 }
 
 .widget-card__tag {
   position: absolute;
-  top: -14px;
+  top: clamp(-24px, -3.6vw, -14px);
   left: 50%;
   transform: translateX(-50%);
   background: linear-gradient(120deg, #ff8f4b, #ff6f32);
   color: #130a05;
-  font-size: 0.75rem;
+  font-size: clamp(0.65rem, 0.55rem + 0.3vw, 0.78rem);
   letter-spacing: 0.15em;
   text-transform: uppercase;
-  padding: 0.35rem 1.25rem;
+  padding: clamp(0.28rem, 0.18rem + 0.2vw, 0.38rem)
+    clamp(0.9rem, 0.6rem + 0.8vw, 1.45rem);
   border-radius: 999px;
   box-shadow: 0 10px 30px rgba(255, 120, 40, 0.45);
 }
 
 .widget-card__title {
   margin: 0.5rem 0 0.25rem;
-  font-size: clamp(1.4rem, 2.5vw, 1.75rem);
+  font-size: clamp(1.25rem, 0.7rem + 1.8vw, 1.75rem);
   color: #ffe3ca;
 }
 
@@ -230,6 +233,8 @@ a:hover {
   line-height: 1.6;
   max-width: 320px;
   color: rgba(255, 230, 210, 0.8);
+  font-size: clamp(0.94rem, 0.72rem + 0.5vw, 1.05rem);
+  margin-bottom: clamp(1rem, 0.6rem + 1vw, 1.75rem);
 }
 
 .widget-card__action {
@@ -239,7 +244,8 @@ a:hover {
   gap: 0.5rem;
   font-weight: 600;
   letter-spacing: 0.05em;
-  padding: 0.85rem 1.85rem;
+  padding: clamp(0.7rem, 0.5rem + 0.5vw, 0.95rem)
+    clamp(1.25rem, 0.95rem + 0.8vw, 1.85rem);
   border-radius: 999px;
   background: linear-gradient(120deg, #ff8f4b, #ff6f32);
   color: #150904;
@@ -247,6 +253,7 @@ a:hover {
   box-shadow: 0 15px 35px rgba(255, 120, 40, 0.45);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
   margin-top: auto;
+  font-size: clamp(0.82rem, 0.7rem + 0.35vw, 0.95rem);
 }
 
 .widget-card__action:hover {


### PR DESCRIPTION
## Summary
- scale widget card typography, spacing, and button padding with viewport units to keep square cards legible across breakpoints
- allow the widget label pill to float above the card while maintaining the square aspect ratio

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68da58eac8b88321beb5f0b79379d734