### PR TITLE
Add Imagine Craft creative workshop widget

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -41,6 +41,17 @@ export default function HomePage() {
               Jugar una partida
             </Link>
           </article>
+
+          <article className="widget-card">
+            <span className="widget-card__tag">Imagine Craft</span>
+            <h3 className="widget-card__title">Fusiona ideas y elementos</h3>
+            <p className="widget-card__description">
+              Diseña tus propios cuadros, arrástralos y descubre combinaciones dinámicas inspiradas en Infinite Craft.
+            </p>
+            <Link className="widget-card__action" href="/widgets/imagine-craft">
+              Abrir el taller creativo
+            </Link>
+          </article>
         </section>
       </div>
     </main>

--- a/app/widgets/imagine-craft/ImagineCraftWorkshop.js
+++ b/app/widgets/imagine-craft/ImagineCraftWorkshop.js
@@ -1,0 +1,647 @@
+'use client';
+
+import { useMemo, useRef, useState } from 'react';
+import styles from './ImagineCraftWorkshop.module.css';
+
+const TYPE_OPTIONS = [
+  'Elemento',
+  'Energía',
+  'Naturaleza',
+  'Materia',
+  'Fenómeno',
+  'Tecnología',
+  'Arte',
+  'Concepto',
+  'Historia',
+  'Ser',
+  'Idea',
+  'Quimera',
+];
+
+const INITIAL_PALETTE = [
+  { name: 'Agua', type: 'Elemento' },
+  { name: 'Fuego', type: 'Elemento' },
+  { name: 'Tierra', type: 'Elemento' },
+  { name: 'Aire', type: 'Elemento' },
+  { name: 'Luz', type: 'Energía' },
+  { name: 'Sombra', type: 'Energía' },
+  { name: 'Semilla', type: 'Naturaleza' },
+  { name: 'Tiempo', type: 'Concepto' },
+  { name: 'Metal', type: 'Materia' },
+  { name: 'Melodía', type: 'Arte' },
+];
+
+function comboKey(a, b) {
+  return [a, b]
+    .map((value) => value.toLowerCase())
+    .sort()
+    .join('::');
+}
+
+const EXACT_COMBINATIONS = new Map([
+  [
+    comboKey('Agua', 'Fuego'),
+    {
+      name: 'Vapor',
+      type: 'Fenómeno',
+      lore: 'La niebla cálida de una reacción elemental.',
+    },
+  ],
+  [
+    comboKey('Agua', 'Aire'),
+    {
+      name: 'Niebla',
+      type: 'Fenómeno',
+      lore: 'Una nube baja se desliza sobre el taller.',
+    },
+  ],
+  [
+    comboKey('Agua', 'Tierra'),
+    {
+      name: 'Barro',
+      type: 'Materia',
+      lore: 'Pasta maleable que guarda potencial artístico.',
+    },
+  ],
+  [
+    comboKey('Fuego', 'Aire'),
+    {
+      name: 'Chispa',
+      type: 'Energía',
+      lore: 'Un destello fugaz listo para alimentar ideas.',
+    },
+  ],
+  [
+    comboKey('Fuego', 'Tierra'),
+    {
+      name: 'Aleación viva',
+      type: 'Tecnología',
+      lore: 'Metal que aún palpita con el calor de la forja.',
+    },
+  ],
+  [
+    comboKey('Tierra', 'Semilla'),
+    {
+      name: 'Bosque miniatura',
+      type: 'Naturaleza',
+      lore: 'Un ecosistema diminuto cobra vida sobre la mesa.',
+    },
+  ],
+  [
+    comboKey('Agua', 'Semilla'),
+    {
+      name: 'Brote',
+      type: 'Naturaleza',
+      lore: 'Un tallo verde que busca la luz del taller.',
+    },
+  ],
+  [
+    comboKey('Luz', 'Agua'),
+    {
+      name: 'Arcoíris de estudio',
+      type: 'Fenómeno',
+      lore: 'Colores suspendidos sobre el espacio de trabajo.',
+    },
+  ],
+  [
+    comboKey('Luz', 'Sombra'),
+    {
+      name: 'Crepúsculo',
+      type: 'Fenómeno',
+      lore: 'Un equilibrio perfecto entre claridad y misterio.',
+    },
+  ],
+  [
+    comboKey('Luz', 'Tiempo'),
+    {
+      name: 'Aurora detenida',
+      type: 'Historia',
+      lore: 'Un amanecer congelado en un instante eterno.',
+    },
+  ],
+  [
+    comboKey('Sombra', 'Tiempo'),
+    {
+      name: 'Eco antiguo',
+      type: 'Historia',
+      lore: 'Susurros de épocas pasadas resuenan en la sala.',
+    },
+  ],
+  [
+    comboKey('Metal', 'Fuego'),
+    {
+      name: 'Espada forjada',
+      type: 'Arte',
+      lore: 'Una hoja brillante recién templada.',
+    },
+  ],
+  [
+    comboKey('Metal', 'Semilla'),
+    {
+      name: 'Jardín mecánico',
+      type: 'Quimera',
+      lore: 'Plantas de engranajes que florecen con precisión.',
+    },
+  ],
+  [
+    comboKey('Melodía', 'Aire'),
+    {
+      name: 'Canción viajera',
+      type: 'Arte',
+      lore: 'Notas que flotan y recorren el taller.',
+    },
+  ],
+  [
+    comboKey('Melodía', 'Tiempo'),
+    {
+      name: 'Sinfonía eterna',
+      type: 'Concepto',
+      lore: 'Un motivo musical que nunca se repite igual.',
+    },
+  ],
+]);
+
+const TYPE_COMBINATIONS = new Map([
+  [
+    comboKey('Elemento', 'Naturaleza'),
+    {
+      name: 'Clima viviente',
+      type: 'Fenómeno',
+      lore: 'Los elementos moldean la vida y la vida guía a los elementos.',
+    },
+  ],
+  [
+    comboKey('Elemento', 'Energía'),
+    {
+      name: 'Tormenta resonante',
+      type: 'Fenómeno',
+      lore: 'Relámpagos que laten al ritmo de una idea.',
+    },
+  ],
+  [
+    comboKey('Naturaleza', 'Tecnología'),
+    {
+      name: 'Bioingeniería',
+      type: 'Tecnología',
+      lore: 'Circuitos que crecen como raíces entrelazadas.',
+    },
+  ],
+  [
+    comboKey('Concepto', 'Naturaleza'),
+    {
+      name: 'Leyenda viva',
+      type: 'Historia',
+      lore: 'Los mitos caminan con patas y hojas.',
+    },
+  ],
+  [
+    comboKey('Arte', 'Tecnología'),
+    {
+      name: 'Holograma lírico',
+      type: 'Arte',
+      lore: 'Esculturas de luz que bailan con la música.',
+    },
+  ],
+  [
+    comboKey('Materia', 'Energía'),
+    {
+      name: 'Reactor improvisado',
+      type: 'Tecnología',
+      lore: 'Materias primas vibran convertidas en energía utilizable.',
+    },
+  ],
+  [
+    comboKey('Concepto', 'Concepto'),
+    {
+      name: 'Filosofía portátil',
+      type: 'Idea',
+      lore: 'Un pensamiento listo para acompañarte a todas partes.',
+    },
+  ],
+  [
+    comboKey('Fenómeno', 'Tecnología'),
+    {
+      name: 'Sensor climático',
+      type: 'Tecnología',
+      lore: 'Una máquina que traduce eventos naturales en datos musicales.',
+    },
+  ],
+  [
+    comboKey('Historia', 'Concepto'),
+    {
+      name: 'Crónica visionaria',
+      type: 'Historia',
+      lore: 'Relatos que predicen futuros posibles.',
+    },
+  ],
+  [
+    comboKey('Arte', 'Naturaleza'),
+    {
+      name: 'Galería botánica',
+      type: 'Arte',
+      lore: 'Un museo vivo que florece frente a tus ojos.',
+    },
+  ],
+]);
+
+function titleCase(text) {
+  return text
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((word) => word[0].toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+function resolveCombination(entityA, entityB) {
+  const exact = EXACT_COMBINATIONS.get(comboKey(entityA.name, entityB.name));
+  if (exact) {
+    return exact;
+  }
+
+  const typed = TYPE_COMBINATIONS.get(comboKey(entityA.type, entityB.type));
+  if (typed) {
+    return typed;
+  }
+
+  const typeKey = `${entityA.type} + ${entityB.type}`;
+  return {
+    name: `Quimera de ${entityA.type} y ${entityB.type}`,
+    type: 'Quimera',
+    lore: `Una creación inesperada nacida de combinar ${typeKey.toLowerCase()}.`,
+  };
+}
+
+function ImagineCraftWorkshop() {
+  const workspaceRef = useRef(null);
+  const paletteCounterRef = useRef(0);
+  const boardCounterRef = useRef(0);
+  const paletteMapRef = useRef(new Map());
+
+  const [palette, setPalette] = useState(() => {
+    paletteCounterRef.current = INITIAL_PALETTE.length;
+    return INITIAL_PALETTE.map((item, index) => {
+      const key = item.name.toLowerCase();
+      const element = {
+        ...item,
+        id: `palette-${index}`,
+        key,
+        origin: 'seed',
+      };
+      paletteMapRef.current.set(key, element);
+      return element;
+    });
+  });
+
+  const [boardElements, setBoardElements] = useState([]);
+  const [nameInput, setNameInput] = useState('');
+  const [typeInput, setTypeInput] = useState(TYPE_OPTIONS[0]);
+  const [log, setLog] = useState([
+    'Arrastra cuadros desde la barra inferior para poblar el espacio creativo.',
+  ]);
+  const [statusMessage, setStatusMessage] = useState('Listo para crear nuevas combinaciones.');
+  const [draggingId, setDraggingId] = useState(null);
+
+  const paletteById = useMemo(() => {
+    const map = new Map();
+    palette.forEach((item) => {
+      map.set(item.id, item);
+    });
+    return map;
+  }, [palette]);
+
+  const boardById = useMemo(() => {
+    const map = new Map();
+    boardElements.forEach((item) => {
+      map.set(item.id, item);
+    });
+    return map;
+  }, [boardElements]);
+
+  const registerPaletteElement = (name, type, origin = 'custom') => {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      return { added: false };
+    }
+    const formattedName = titleCase(trimmed);
+    const key = formattedName.toLowerCase();
+    if (paletteMapRef.current.has(key)) {
+      return { added: false, element: paletteMapRef.current.get(key) };
+    }
+
+    const normalizedType = type || 'Idea';
+    const element = {
+      id: `palette-${paletteCounterRef.current}`,
+      name: formattedName,
+      type: normalizedType,
+      key,
+      origin,
+    };
+    paletteCounterRef.current += 1;
+    paletteMapRef.current.set(key, element);
+    setPalette((prev) => [...prev, element]);
+    return { added: true, element };
+  };
+
+  const appendLog = (entry) => {
+    setLog((prev) => {
+      const next = [...prev, entry];
+      return next.slice(-8);
+    });
+  };
+
+  const handleAddElement = (event) => {
+    event.preventDefault();
+    if (!nameInput.trim()) {
+      setStatusMessage('Necesitas escribir un nombre para crear un nuevo cuadro.');
+      return;
+    }
+    const { added, element } = registerPaletteElement(nameInput, typeInput, 'manual');
+    if (added) {
+      setStatusMessage(`Nuevo cuadro disponible: ${element.name} (${element.type}).`);
+      appendLog(`Has preparado ${element.name} y lo has guardado en la barra creativa.`);
+    } else {
+      setStatusMessage(`El cuadro ${titleCase(nameInput)} ya existe en tu biblioteca.`);
+    }
+    setNameInput('');
+  };
+
+  const handlePaletteDragStart = (event, element) => {
+    event.dataTransfer.setData(
+      'application/json',
+      JSON.stringify({ source: 'palette', paletteId: element.id })
+    );
+    event.dataTransfer.effectAllowed = 'copy';
+    setDraggingId(element.id);
+  };
+
+  const handleBoardDragStart = (event, element) => {
+    event.dataTransfer.setData(
+      'application/json',
+      JSON.stringify({ source: 'board', boardId: element.id })
+    );
+    event.dataTransfer.effectAllowed = 'move';
+    setDraggingId(element.id);
+  };
+
+  const handleDragEnd = () => {
+    setDraggingId(null);
+  };
+
+  const getWorkspaceCoordinates = (event) => {
+    const workspace = workspaceRef.current;
+    if (!workspace) {
+      return { x: 0, y: 0 };
+    }
+    const rect = workspace.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    const y = event.clientY - rect.top;
+    return { x, y };
+  };
+
+  const placeOnWorkspace = (element, coords) => {
+    const newElement = {
+      id: `board-${boardCounterRef.current}`,
+      name: element.name,
+      type: element.type,
+      x: coords.x,
+      y: coords.y,
+    };
+    boardCounterRef.current += 1;
+    setBoardElements((prev) => [...prev, newElement]);
+    return newElement;
+  };
+
+  const handleWorkspaceDrop = (event) => {
+    event.preventDefault();
+    const raw = event.dataTransfer.getData('application/json');
+    if (!raw) return;
+    let data;
+    try {
+      data = JSON.parse(raw);
+    } catch (error) {
+      return;
+    }
+
+    const coords = getWorkspaceCoordinates(event);
+
+    if (data.source === 'palette') {
+      const paletteElement = paletteById.get(data.paletteId);
+      if (!paletteElement) return;
+      placeOnWorkspace(paletteElement, coords);
+      setStatusMessage(`Has colocado ${paletteElement.name} en el espacio creativo.`);
+    } else if (data.source === 'board') {
+      const moving = boardById.get(data.boardId);
+      if (!moving) return;
+      setBoardElements((prev) =>
+        prev.map((item) =>
+          item.id === moving.id
+            ? {
+                ...item,
+                x: coords.x,
+                y: coords.y,
+              }
+            : item
+        )
+      );
+    }
+  };
+
+  const handleWorkspaceDragOver = (event) => {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'copy';
+  };
+
+  const handleElementDragOver = (event) => {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'link';
+  };
+
+  const handleElementDrop = (event, targetId) => {
+    event.preventDefault();
+    const raw = event.dataTransfer.getData('application/json');
+    if (!raw) return;
+    let data;
+    try {
+      data = JSON.parse(raw);
+    } catch (error) {
+      return;
+    }
+
+    const target = boardById.get(targetId);
+    if (!target) return;
+
+    const coords = getWorkspaceCoordinates(event);
+
+    if (data.source === 'palette') {
+      const paletteElement = paletteById.get(data.paletteId);
+      if (!paletteElement) return;
+      const result = resolveCombination(paletteElement, target);
+      placeOnWorkspace(result, {
+        x: coords.x + 24,
+        y: coords.y + 24,
+      });
+      setBoardElements((prev) => prev.filter((item) => item.id !== target.id));
+      const { added } = registerPaletteElement(result.name, result.type, 'discovered');
+      setStatusMessage(
+        `✨ ${paletteElement.name} y ${target.name} dieron lugar a ${result.name}. ${
+          added ? 'Se añadió a tu barra creativa.' : 'Ya formaba parte de tu biblioteca.'
+        }`
+      );
+      appendLog(
+        `${paletteElement.name} + ${target.name} → ${result.name}. ${result.lore}`
+      );
+    } else if (data.source === 'board') {
+      const other = boardById.get(data.boardId);
+      if (!other || other.id === target.id) return;
+      const result = resolveCombination(other, target);
+      const merged = {
+        id: `board-${boardCounterRef.current}`,
+        name: result.name,
+        type: result.type,
+        x: (other.x + target.x) / 2,
+        y: (other.y + target.y) / 2,
+      };
+      boardCounterRef.current += 1;
+      setBoardElements((prev) =>
+        prev
+          .filter((item) => item.id !== target.id && item.id !== other.id)
+          .concat({
+            ...merged,
+            x: coords.x,
+            y: coords.y,
+          })
+      );
+      const { added } = registerPaletteElement(result.name, result.type, 'discovered');
+      setStatusMessage(
+        `✨ ${other.name} y ${target.name} se fusionaron en ${result.name}. ${
+          added ? 'Nuevo cuadro desbloqueado.' : 'Lo recuperaste de tu biblioteca.'
+        }`
+      );
+      appendLog(`${other.name} + ${target.name} → ${result.name}. ${result.lore}`);
+    }
+  };
+
+  return (
+    <section className={styles.page}>
+      <header className={styles.header}>
+        <div>
+          <p className={styles.breadcrumb}>Widget creativo</p>
+          <h1 className={styles.title}>Imagine Craft</h1>
+          <p className={styles.subtitle}>
+            Diseña combinaciones al estilo de un taller infinito: crea tus propios cuadros, arrástralos y
+            descubre resultados sorprendentes.
+          </p>
+        </div>
+        <div className={styles.status}>{statusMessage}</div>
+      </header>
+
+      <form className={styles.creator} onSubmit={handleAddElement}>
+        <label className={styles.creatorLabel} htmlFor="element-name">
+          Crea un nuevo cuadro
+        </label>
+        <div className={styles.creatorRow}>
+          <input
+            id="element-name"
+            type="text"
+            placeholder="Escribe un concepto, elemento o idea"
+            value={nameInput}
+            onChange={(event) => setNameInput(event.target.value)}
+            className={styles.input}
+          />
+          <select
+            value={typeInput}
+            onChange={(event) => setTypeInput(event.target.value)}
+            className={styles.select}
+          >
+            {TYPE_OPTIONS.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+          <button type="submit" className={styles.button}>
+            Añadir cuadro
+          </button>
+        </div>
+      </form>
+
+      <div className={styles.mainArea}>
+        <div className={styles.workspaceWrapper}>
+          <div
+            ref={workspaceRef}
+            className={styles.workspace}
+            onDragOver={handleWorkspaceDragOver}
+            onDrop={handleWorkspaceDrop}
+          >
+            {boardElements.length === 0 && (
+              <p className={styles.workspaceHint}>
+                Arrastra elementos desde la barra inferior o combina directamente sobre otros cuadros.
+              </p>
+            )}
+            {boardElements.map((element) => (
+              <div
+                key={element.id}
+                className={`${styles.token} ${
+                  draggingId === element.id ? styles.tokenDragging : ''
+                }`}
+                style={{ left: `${element.x}px`, top: `${element.y}px` }}
+                draggable
+                onDragStart={(event) => handleBoardDragStart(event, element)}
+                onDragEnd={handleDragEnd}
+                onDrop={(event) => handleElementDrop(event, element.id)}
+                onDragOver={handleElementDragOver}
+              >
+                <span className={styles.tokenName}>{element.name}</span>
+                <span className={styles.tokenType}>{element.type}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+        <aside className={styles.sidePanel}>
+          <h2 className={styles.panelTitle}>Bitácora de mezclas</h2>
+          <ul className={styles.logList}>
+            {log.map((entry, index) => (
+              <li key={`${entry}-${index}`} className={styles.logEntry}>
+                {entry}
+              </li>
+            ))}
+          </ul>
+          <div className={styles.paletteSummary}>
+            <p>
+              Biblioteca activa: <strong>{palette.length}</strong> cuadros disponibles.
+            </p>
+            <p className={styles.summaryHint}>
+              Cada descubrimiento exitoso se añadirá automáticamente a tu barra creativa.
+            </p>
+          </div>
+        </aside>
+      </div>
+
+      <footer className={styles.paletteBar}>
+        <div className={styles.paletteHeader}>
+          <h2>Barra creativa</h2>
+          <p>Arrastra cualquier cuadro para clonarlo en el espacio de trabajo.</p>
+        </div>
+        <div className={styles.paletteScroller}>
+          {palette.map((element) => (
+            <div
+              key={element.id}
+              className={`${styles.paletteItem} ${
+                draggingId === element.id ? styles.tokenDragging : ''
+              }`}
+              draggable
+              onDragStart={(event) => handlePaletteDragStart(event, element)}
+              onDragEnd={handleDragEnd}
+            >
+              <span className={styles.paletteName}>{element.name}</span>
+              <span className={styles.paletteType}>{element.type}</span>
+            </div>
+          ))}
+        </div>
+      </footer>
+    </section>
+  );
+}
+
+export default ImagineCraftWorkshop;

--- a/app/widgets/imagine-craft/ImagineCraftWorkshop.module.css
+++ b/app/widgets/imagine-craft/ImagineCraftWorkshop.module.css
@@ -1,0 +1,308 @@
+.page {
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: clamp(1.5rem, 2vw, 2.5rem) clamp(1.5rem, 4vw, 3rem) 8rem;
+  background:
+    radial-gradient(120% 120% at 0% 0%, rgba(130, 80, 255, 0.12), transparent 60%),
+    radial-gradient(90% 110% at 100% 0%, rgba(255, 120, 80, 0.1), transparent 65%),
+    linear-gradient(180deg, rgba(8, 8, 8, 0.95) 0%, rgba(4, 4, 4, 0.95) 100%);
+}
+
+.header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 1.5rem;
+  padding: clamp(1.25rem, 1rem + 1vw, 1.75rem);
+  border: 1px solid rgba(255, 145, 80, 0.28);
+  border-radius: 24px;
+  background: linear-gradient(135deg, rgba(26, 16, 35, 0.85), rgba(20, 12, 12, 0.75));
+  box-shadow: 0 20px 45px rgba(0, 0, 0, 0.35);
+}
+
+.breadcrumb {
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  font-size: 0.7rem;
+  color: rgba(255, 200, 160, 0.62);
+  margin-bottom: 0.65rem;
+}
+
+.title {
+  margin: 0;
+  font-size: clamp(2.4rem, 1.6rem + 2vw, 3.3rem);
+  color: #ffe6d1;
+}
+
+.subtitle {
+  margin: 0.25rem 0 0;
+  max-width: 640px;
+  line-height: 1.6;
+  color: rgba(255, 230, 215, 0.8);
+}
+
+.status {
+  margin-left: auto;
+  font-size: 0.95rem;
+  color: rgba(255, 210, 180, 0.9);
+  padding: 0.65rem 1rem;
+  border-radius: 999px;
+  background: linear-gradient(120deg, rgba(255, 140, 66, 0.25), rgba(255, 110, 80, 0.35));
+  border: 1px solid rgba(255, 160, 120, 0.35);
+}
+
+.creator {
+  display: grid;
+  gap: 0.75rem;
+  padding: clamp(1rem, 0.8rem + 1vw, 1.75rem);
+  border-radius: 22px;
+  border: 1px solid rgba(120, 90, 255, 0.2);
+  background: linear-gradient(135deg, rgba(18, 18, 30, 0.82), rgba(12, 12, 18, 0.92));
+  box-shadow: inset 0 0 24px rgba(120, 90, 255, 0.18);
+}
+
+.creatorLabel {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: rgba(215, 205, 255, 0.86);
+}
+
+.creatorRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.input,
+.select {
+  border-radius: 999px;
+  border: 1px solid rgba(120, 90, 255, 0.35);
+  background: rgba(18, 16, 35, 0.7);
+  color: #f6f1ff;
+  padding: 0.85rem 1.15rem;
+  font-size: 1rem;
+  letter-spacing: 0.01em;
+  min-width: 0;
+}
+
+.input::placeholder {
+  color: rgba(200, 190, 255, 0.45);
+}
+
+.select {
+  min-width: 10rem;
+}
+
+.button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.85rem 1.65rem;
+  background: linear-gradient(120deg, #ff9456, #ff7b53);
+  color: #160800;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  box-shadow: 0 12px 30px rgba(255, 120, 80, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 38px rgba(255, 120, 80, 0.45);
+}
+
+.mainArea {
+  display: grid;
+  gap: clamp(1.5rem, 1rem + 2vw, 2.5rem);
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.workspaceWrapper {
+  position: relative;
+  border-radius: 28px;
+  border: 1px solid rgba(255, 165, 110, 0.28);
+  background: linear-gradient(160deg, rgba(24, 12, 16, 0.88), rgba(12, 8, 10, 0.95));
+  min-height: clamp(360px, 60vh, 560px);
+  overflow: hidden;
+}
+
+.workspace {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  cursor: grab;
+}
+
+.workspaceHint {
+  position: absolute;
+  inset: 50% auto auto 50%;
+  transform: translate(-50%, -50%);
+  max-width: 360px;
+  text-align: center;
+  color: rgba(255, 220, 190, 0.65);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.token {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  display: grid;
+  gap: 0.25rem;
+  justify-items: center;
+  text-align: center;
+  padding: 0.85rem 1.1rem;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 185, 120, 0.35);
+  background: linear-gradient(145deg, rgba(255, 180, 120, 0.25), rgba(18, 10, 8, 0.85));
+  box-shadow:
+    0 18px 32px rgba(0, 0, 0, 0.35),
+    inset 0 0 22px rgba(255, 165, 100, 0.28);
+  min-width: 140px;
+  user-select: none;
+}
+
+.tokenDragging {
+  opacity: 0.6;
+  box-shadow: 0 0 0 2px rgba(255, 195, 120, 0.5);
+}
+
+.tokenName {
+  font-weight: 600;
+  font-size: 1.05rem;
+  color: #ffe9d8;
+}
+
+.tokenType {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: rgba(255, 220, 185, 0.68);
+}
+
+.sidePanel {
+  border-radius: 24px;
+  border: 1px solid rgba(120, 90, 255, 0.25);
+  background: linear-gradient(160deg, rgba(14, 14, 28, 0.85), rgba(10, 8, 22, 0.95));
+  padding: clamp(1.1rem, 0.9rem + 1vw, 1.8rem);
+  display: grid;
+  gap: 1.25rem;
+}
+
+.panelTitle {
+  margin: 0;
+  font-size: 1.25rem;
+  color: rgba(215, 205, 255, 0.9);
+}
+
+.logList {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.75rem;
+  max-height: 260px;
+  overflow-y: auto;
+}
+
+.logEntry {
+  font-size: 0.92rem;
+  line-height: 1.5;
+  color: rgba(220, 210, 255, 0.78);
+  background: rgba(120, 90, 255, 0.08);
+  border-radius: 16px;
+  padding: 0.65rem 0.85rem;
+  border: 1px solid rgba(120, 90, 255, 0.18);
+}
+
+.paletteSummary {
+  font-size: 0.95rem;
+  color: rgba(210, 200, 255, 0.8);
+  line-height: 1.5;
+}
+
+.summaryHint {
+  color: rgba(190, 180, 240, 0.65);
+  font-size: 0.85rem;
+}
+
+.paletteBar {
+  margin-top: auto;
+  border-radius: 26px 26px 0 0;
+  border: 1px solid rgba(255, 140, 80, 0.25);
+  background: linear-gradient(180deg, rgba(20, 12, 12, 0.95), rgba(18, 10, 8, 0.98));
+  padding: clamp(1.25rem, 1rem + 1vw, 2rem);
+  display: grid;
+  gap: 1rem;
+  box-shadow: 0 -14px 35px rgba(0, 0, 0, 0.35);
+}
+
+.paletteHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  color: rgba(255, 215, 190, 0.85);
+}
+
+.paletteScroller {
+  display: grid;
+  gap: 0.75rem;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(160px, 1fr);
+  overflow-x: auto;
+  padding-bottom: 0.5rem;
+}
+
+.paletteItem {
+  border-radius: 18px;
+  border: 1px solid rgba(255, 175, 120, 0.3);
+  background: linear-gradient(135deg, rgba(255, 180, 120, 0.18), rgba(16, 10, 8, 0.9));
+  padding: 0.9rem 1.1rem;
+  display: grid;
+  gap: 0.35rem;
+  justify-items: center;
+  cursor: grab;
+  box-shadow:
+    0 12px 26px rgba(0, 0, 0, 0.32),
+    inset 0 0 18px rgba(255, 180, 120, 0.18);
+  user-select: none;
+}
+
+.paletteItem:active {
+  cursor: grabbing;
+}
+
+.paletteName {
+  font-weight: 600;
+  color: #ffe9d8;
+}
+
+.paletteType {
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(255, 210, 180, 0.6);
+}
+
+@media (min-width: 1080px) {
+  .mainArea {
+    grid-template-columns: minmax(0, 1.7fr) minmax(260px, 0.9fr);
+  }
+}
+
+@media (max-width: 720px) {
+  .page {
+    padding-bottom: 12rem;
+  }
+
+  .workspaceWrapper {
+    min-height: 320px;
+  }
+
+  .paletteScroller {
+    grid-auto-columns: minmax(140px, 1fr);
+  }
+}

--- a/app/widgets/imagine-craft/page.js
+++ b/app/widgets/imagine-craft/page.js
@@ -1,0 +1,11 @@
+import ImagineCraftWorkshop from './ImagineCraftWorkshop';
+
+export const metadata = {
+  title: 'Imagine Craft | Rodrigoplk playground',
+  description:
+    'Crea cuadros personalizados, combínalos y descubre resultados inesperados en este taller infinito de ideas.',
+};
+
+export default function ImagineCraftPage() {
+  return <ImagineCraftWorkshop />;
+}


### PR DESCRIPTION
## Summary
- add the Imagine Craft widget with draggable tiles, combination logic and discovery log
- seed the workshop with typed elements, exact and type-based recipes, and graceful fallbacks for new ideas
- expose the widget from the home page so it is easy to launch

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd86ff27488321864565be0a388107