### PR TITLE
Fix Imagine Craft token fusion cleanup and show combination details

### DIFF
--- a/app/widgets/imagine-craft/ImagineCraftWorkshop.module.css
+++ b/app/widgets/imagine-craft/ImagineCraftWorkshop.module.css
@@ -198,6 +198,72 @@
   color: rgba(215, 205, 255, 0.9);
 }
 
+.fusionPanel {
+  border-radius: 18px;
+  border: 1px solid rgba(150, 120, 255, 0.35);
+  background: linear-gradient(150deg, rgba(36, 28, 60, 0.85), rgba(20, 14, 36, 0.92));
+  padding: 1rem 1.25rem;
+  display: grid;
+  gap: 0.75rem;
+  box-shadow: inset 0 0 18px rgba(150, 120, 255, 0.18);
+}
+
+.fusionHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.fusionTitle {
+  margin: 0;
+  font-size: 1.15rem;
+  color: rgba(235, 225, 255, 0.92);
+}
+
+.fusionType {
+  margin: 0;
+  font-size: 0.8rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(200, 185, 255, 0.6);
+}
+
+.fusionHint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(215, 205, 255, 0.65);
+}
+
+.fusionList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.fusionItem {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.65rem 0.75rem;
+  border-radius: 12px;
+  background: rgba(80, 60, 150, 0.22);
+  border: 1px solid rgba(150, 120, 255, 0.25);
+}
+
+.fusionItemName {
+  font-weight: 600;
+  color: rgba(235, 225, 255, 0.9);
+}
+
+.fusionItemType {
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(200, 190, 255, 0.6);
+}
+
 .logList {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
## Summary
- ensure Imagine Craft board fusions remove the dragged token and don't bubble drop events
- track combination metadata so clicking a fusion reveals its component cards in a new panel

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de227dafa883218a7e48f1d9c4d1b6