### PR TITLE
Enhance Imagine Craft combinations and add base navigation

### DIFF
--- a/app/widgets/imagine-craft/ImagineCraftWorkshop.js
+++ b/app/widgets/imagine-craft/ImagineCraftWorkshop.js
@@ -1,6 +1,7 @@
 'use client';
 
-import { useMemo, useRef, useState } from 'react';
+import Link from 'next/link';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import styles from './ImagineCraftWorkshop.module.css';
 
 const TYPE_OPTIONS = [
@@ -31,6 +32,8 @@ const INITIAL_PALETTE = [
   { name: 'Melodía', type: 'Arte' },
 ];
 
+const BASE_NAMES = new Set(INITIAL_PALETTE.map((item) => item.name));
+
 function comboKey(a, b) {
   return [a, b]
     .map((value) => value.toLowerCase())
@@ -38,128 +41,434 @@ function comboKey(a, b) {
     .join('::');
 }
 
-const EXACT_COMBINATIONS = new Map([
-  [
-    comboKey('Agua', 'Fuego'),
-    {
+const EXACT_COMBINATION_DATA = [
+  {
+    sources: ['Agua', 'Fuego'],
+    result: {
       name: 'Vapor',
       type: 'Fenómeno',
       lore: 'La niebla cálida de una reacción elemental.',
     },
-  ],
-  [
-    comboKey('Agua', 'Aire'),
-    {
+  },
+  {
+    sources: ['Agua', 'Aire'],
+    result: {
       name: 'Niebla',
       type: 'Fenómeno',
       lore: 'Una nube baja se desliza sobre el taller.',
     },
-  ],
-  [
-    comboKey('Agua', 'Tierra'),
-    {
+  },
+  {
+    sources: ['Agua', 'Tierra'],
+    result: {
       name: 'Barro',
       type: 'Materia',
       lore: 'Pasta maleable que guarda potencial artístico.',
     },
-  ],
-  [
-    comboKey('Fuego', 'Aire'),
-    {
+  },
+  {
+    sources: ['Fuego', 'Aire'],
+    result: {
       name: 'Chispa',
       type: 'Energía',
       lore: 'Un destello fugaz listo para alimentar ideas.',
     },
-  ],
-  [
-    comboKey('Fuego', 'Tierra'),
-    {
+  },
+  {
+    sources: ['Fuego', 'Tierra'],
+    result: {
       name: 'Aleación viva',
       type: 'Tecnología',
       lore: 'Metal que aún palpita con el calor de la forja.',
     },
-  ],
-  [
-    comboKey('Tierra', 'Semilla'),
-    {
+  },
+  {
+    sources: ['Tierra', 'Semilla'],
+    result: {
       name: 'Bosque miniatura',
       type: 'Naturaleza',
       lore: 'Un ecosistema diminuto cobra vida sobre la mesa.',
     },
-  ],
-  [
-    comboKey('Agua', 'Semilla'),
-    {
+  },
+  {
+    sources: ['Agua', 'Semilla'],
+    result: {
       name: 'Brote',
       type: 'Naturaleza',
       lore: 'Un tallo verde que busca la luz del taller.',
     },
-  ],
-  [
-    comboKey('Luz', 'Agua'),
-    {
+  },
+  {
+    sources: ['Luz', 'Agua'],
+    result: {
       name: 'Arcoíris de estudio',
       type: 'Fenómeno',
       lore: 'Colores suspendidos sobre el espacio de trabajo.',
     },
-  ],
-  [
-    comboKey('Luz', 'Sombra'),
-    {
+  },
+  {
+    sources: ['Luz', 'Sombra'],
+    result: {
       name: 'Crepúsculo',
       type: 'Fenómeno',
       lore: 'Un equilibrio perfecto entre claridad y misterio.',
     },
-  ],
-  [
-    comboKey('Luz', 'Tiempo'),
-    {
+  },
+  {
+    sources: ['Luz', 'Tiempo'],
+    result: {
       name: 'Aurora detenida',
       type: 'Historia',
       lore: 'Un amanecer congelado en un instante eterno.',
     },
-  ],
-  [
-    comboKey('Sombra', 'Tiempo'),
-    {
+  },
+  {
+    sources: ['Sombra', 'Tiempo'],
+    result: {
       name: 'Eco antiguo',
       type: 'Historia',
       lore: 'Susurros de épocas pasadas resuenan en la sala.',
     },
-  ],
-  [
-    comboKey('Metal', 'Fuego'),
-    {
+  },
+  {
+    sources: ['Metal', 'Fuego'],
+    result: {
       name: 'Espada forjada',
       type: 'Arte',
       lore: 'Una hoja brillante recién templada.',
     },
-  ],
-  [
-    comboKey('Metal', 'Semilla'),
-    {
+  },
+  {
+    sources: ['Metal', 'Semilla'],
+    result: {
       name: 'Jardín mecánico',
       type: 'Quimera',
       lore: 'Plantas de engranajes que florecen con precisión.',
     },
-  ],
-  [
-    comboKey('Melodía', 'Aire'),
-    {
+  },
+  {
+    sources: ['Melodía', 'Aire'],
+    result: {
       name: 'Canción viajera',
       type: 'Arte',
       lore: 'Notas que flotan y recorren el taller.',
     },
-  ],
-  [
-    comboKey('Melodía', 'Tiempo'),
-    {
+  },
+  {
+    sources: ['Melodía', 'Tiempo'],
+    result: {
       name: 'Sinfonía eterna',
       type: 'Concepto',
       lore: 'Un motivo musical que nunca se repite igual.',
     },
-  ],
+  },
+  {
+    sources: ['Agua', 'Metal'],
+    result: {
+      name: 'Óxido viviente',
+      type: 'Materia',
+      lore: 'El metal respira burbujas al ser bañado por corrientes puras.',
+    },
+  },
+  {
+    sources: ['Agua', 'Tiempo'],
+    result: {
+      name: 'Marea eterna',
+      type: 'Historia',
+      lore: 'Las olas guardan memoria de cada estación vivida.',
+    },
+  },
+  {
+    sources: ['Fuego', 'Luz'],
+    result: {
+      name: 'Aurora ígnea',
+      type: 'Fenómeno',
+      lore: 'Lenguas ardientes pintan el cielo del taller.',
+    },
+  },
+  {
+    sources: ['Fuego', 'Sombra'],
+    result: {
+      name: 'Pira crepuscular',
+      type: 'Fenómeno',
+      lore: 'Las llamas oscilan entre el resplandor y el misterio.',
+    },
+  },
+  {
+    sources: ['Tierra', 'Luz'],
+    result: {
+      name: 'Jardín luminoso',
+      type: 'Naturaleza',
+      lore: 'Raíces y destellos comparten un mismo pulso.',
+    },
+  },
+  {
+    sources: ['Tierra', 'Melodía'],
+    result: {
+      name: 'Tambor de arcilla',
+      type: 'Arte',
+      lore: 'Percusiones moldeadas con barro templado.',
+    },
+  },
+  {
+    sources: ['Aire', 'Luz'],
+    result: {
+      name: 'Brisa prisma',
+      type: 'Fenómeno',
+      lore: 'Corrientes que dispersan colores como un abanico.',
+    },
+  },
+  {
+    sources: ['Aire', 'Sombra'],
+    result: {
+      name: 'Susurro umbrío',
+      type: 'Concepto',
+      lore: 'El viento transmite secretos en penumbra.',
+    },
+  },
+  {
+    sources: ['Luz', 'Melodía'],
+    result: {
+      name: 'Ópera solar',
+      type: 'Arte',
+      lore: 'Una puesta en escena bañada por reflejos cálidos.',
+    },
+  },
+  {
+    sources: ['Sombra', 'Semilla'],
+    result: {
+      name: 'Orquídea nocturna',
+      type: 'Naturaleza',
+      lore: 'Florece al ritmo de la penumbra cómplice.',
+    },
+  },
+  {
+    sources: ['Sombra', 'Metal'],
+    result: {
+      name: 'Acero fantasma',
+      type: 'Tecnología',
+      lore: 'Una aleación que aparece y desaparece con la luz.',
+    },
+  },
+  {
+    sources: ['Semilla', 'Luz'],
+    result: {
+      name: 'Invernadero estelar',
+      type: 'Naturaleza',
+      lore: 'Brotan tallos que siguen constelaciones.',
+    },
+  },
+  {
+    sources: ['Tiempo', 'Metal'],
+    result: {
+      name: 'Reloj forjado',
+      type: 'Tecnología',
+      lore: 'Engranajes templados cuentan historias de siglos.',
+    },
+  },
+  {
+    sources: ['Metal', 'Melodía'],
+    result: {
+      name: 'Campana resonante',
+      type: 'Arte',
+      lore: 'Un instrumento forjado que canta al ser tocado.',
+    },
+  },
+  {
+    sources: ['Melodía', 'Agua'],
+    result: {
+      name: 'Coral cantor',
+      type: 'Arte',
+      lore: 'Armonías burbujean desde un arrecife improvisado.',
+    },
+  },
+  {
+    sources: ['Vapor', 'Metal'],
+    result: {
+      name: 'Turbina nebulosa',
+      type: 'Tecnología',
+      lore: 'Nubes cálidas impulsan un motor de precisión.',
+    },
+  },
+  {
+    sources: ['Niebla', 'Luz'],
+    result: {
+      name: 'Halo brumoso',
+      type: 'Fenómeno',
+      lore: 'Un resplandor suave envuelve la niebla flotante.',
+    },
+  },
+  {
+    sources: ['Barro', 'Fuego'],
+    result: {
+      name: 'Cerámica viva',
+      type: 'Arte',
+      lore: 'Arcilla ardiente que toma forma frente a tus ojos.',
+    },
+  },
+  {
+    sources: ['Chispa', 'Melodía'],
+    result: {
+      name: 'Ritmo eléctrico',
+      type: 'Arte',
+      lore: 'Un compás brillante chisporrotea sobre el aire.',
+    },
+  },
+  {
+    sources: ['Aleación viva', 'Melodía'],
+    result: {
+      name: 'Forja sinfónica',
+      type: 'Tecnología',
+      lore: 'Metal pulsante marca el ritmo de cada golpe musical.',
+    },
+  },
+  {
+    sources: ['Bosque miniatura', 'Luz'],
+    result: {
+      name: 'Bosque solar',
+      type: 'Naturaleza',
+      lore: 'Hojitas brillan como paneles diminutos.',
+    },
+  },
+  {
+    sources: ['Brote', 'Tiempo'],
+    result: {
+      name: 'Árbol crónico',
+      type: 'Historia',
+      lore: 'Los anillos del tronco marcan eras completas.',
+    },
+  },
+  {
+    sources: ['Arcoíris de estudio', 'Tierra'],
+    result: {
+      name: 'Prisma mineral',
+      type: 'Arte',
+      lore: 'Cristales terrenales refractan todos los colores.',
+    },
+  },
+  {
+    sources: ['Crepúsculo', 'Melodía'],
+    result: {
+      name: 'Balada crepuscular',
+      type: 'Arte',
+      lore: 'Canciones que aparecen al caer la tarde.',
+    },
+  },
+  {
+    sources: ['Aurora detenida', 'Agua'],
+    result: {
+      name: 'Aurora reflejada',
+      type: 'Fenómeno',
+      lore: 'La aurora se mira en espejos líquidos interminables.',
+    },
+  },
+  {
+    sources: ['Eco antiguo', 'Metal'],
+    result: {
+      name: 'Campana ancestral',
+      type: 'Historia',
+      lore: 'El bronce vibra con historias de antaño.',
+    },
+  },
+  {
+    sources: ['Espada forjada', 'Luz'],
+    result: {
+      name: 'Espada radiante',
+      type: 'Tecnología',
+      lore: 'La hoja absorbe claridad y corta las tinieblas.',
+    },
+  },
+  {
+    sources: ['Jardín mecánico', 'Agua'],
+    result: {
+      name: 'Invernadero mecánico',
+      type: 'Tecnología',
+      lore: 'Ruedas y tallos se riegan con precisión hidráulica.',
+    },
+  },
+  {
+    sources: ['Canción viajera', 'Sombra'],
+    result: {
+      name: 'Serenata de sombras',
+      type: 'Arte',
+      lore: 'Melodías que sólo se escuchan en penumbra.',
+    },
+  },
+  {
+    sources: ['Sinfonía eterna', 'Luz'],
+    result: {
+      name: 'Partitura lumínica',
+      type: 'Arte',
+      lore: 'Cada nota enciende destellos al desplegarse.',
+    },
+  },
+];
+
+const TYPE_ANCHORS = new Map([
+  ['Elemento', 'Agua'],
+  ['Energía', 'Luz'],
+  ['Naturaleza', 'Semilla'],
+  ['Materia', 'Tierra'],
+  ['Fenómeno', 'Aire'],
+  ['Tecnología', 'Metal'],
+  ['Arte', 'Melodía'],
+  ['Concepto', 'Tiempo'],
+  ['Historia', 'Tiempo'],
+  ['Ser', 'Tierra'],
+  ['Idea', 'Tiempo'],
+  ['Quimera', 'Sombra'],
 ]);
+
+function buildExactCombinationMap() {
+  const map = new Map();
+  const catalog = new Map(INITIAL_PALETTE.map(({ name, type }) => [name, type]));
+
+  const addCombination = (sources, result) => {
+    map.set(comboKey(sources[0], sources[1]), result);
+    if (!catalog.has(result.name)) {
+      catalog.set(result.name, result.type);
+    }
+  };
+
+  EXACT_COMBINATION_DATA.forEach(({ sources, result }) => addCombination(sources, result));
+
+  catalog.forEach((type, name) => {
+    const selfKey = comboKey(name, name);
+    if (!map.has(selfKey)) {
+      addCombination(
+        [name, name],
+        {
+          name,
+          type,
+          lore: `La esencia de ${name} se intensifica al reflejarse en sí misma.`,
+        }
+      );
+    }
+
+    if (BASE_NAMES.has(name)) {
+      return;
+    }
+
+    const preferredBase = TYPE_ANCHORS.get(type) || INITIAL_PALETTE[0].name;
+    const baseName = BASE_NAMES.has(preferredBase) ? preferredBase : INITIAL_PALETTE[0].name;
+    const baseKey = comboKey(name, baseName);
+
+    if (!map.has(baseKey)) {
+      addCombination(
+        [name, baseName],
+        {
+          name,
+          type,
+          lore: `${name} absorbe matices de ${baseName.toLowerCase()} y conserva su forma original.`,
+        }
+      );
+    }
+  });
+
+  return map;
+}
+
+const EXACT_COMBINATIONS = buildExactCombinationMap();
 
 const TYPE_COMBINATIONS = new Map([
   [
@@ -301,6 +610,7 @@ function ImagineCraftWorkshop() {
   ]);
   const [statusMessage, setStatusMessage] = useState('Listo para crear nuevas combinaciones.');
   const [draggingId, setDraggingId] = useState(null);
+  const [selectedFusion, setSelectedFusion] = useState(null);
 
   const paletteById = useMemo(() => {
     const map = new Map();
@@ -317,6 +627,16 @@ function ImagineCraftWorkshop() {
     });
     return map;
   }, [boardElements]);
+
+  useEffect(() => {
+    if (!selectedFusion) return;
+    const latest = boardById.get(selectedFusion.result.id);
+    if (!latest) {
+      setSelectedFusion(null);
+    } else if (latest !== selectedFusion.result) {
+      setSelectedFusion({ result: latest, components: latest.components });
+    }
+  }, [boardById, selectedFusion]);
 
   const registerPaletteElement = (name, type, origin = 'custom') => {
     const trimmed = name.trim();
@@ -399,15 +719,21 @@ function ImagineCraftWorkshop() {
     return { x, y };
   };
 
-  const placeOnWorkspace = (element, coords) => {
+  const createBoardElement = (element, coords, metadata = {}) => {
     const newElement = {
       id: `board-${boardCounterRef.current}`,
       name: element.name,
       type: element.type,
       x: coords.x,
       y: coords.y,
+      ...metadata,
     };
     boardCounterRef.current += 1;
+    return newElement;
+  };
+
+  const placeOnWorkspace = (element, coords, metadata) => {
+    const newElement = createBoardElement(element, coords, metadata);
     setBoardElements((prev) => [...prev, newElement]);
     return newElement;
   };
@@ -459,6 +785,7 @@ function ImagineCraftWorkshop() {
 
   const handleElementDrop = (event, targetId) => {
     event.preventDefault();
+    event.stopPropagation();
     const raw = event.dataTransfer.getData('application/json');
     if (!raw) return;
     let data;
@@ -477,11 +804,36 @@ function ImagineCraftWorkshop() {
       const paletteElement = paletteById.get(data.paletteId);
       if (!paletteElement) return;
       const result = resolveCombination(paletteElement, target);
-      placeOnWorkspace(result, {
-        x: coords.x + 24,
-        y: coords.y + 24,
+      const merged = createBoardElement(
+        result,
+        {
+          x: coords.x + 24,
+          y: coords.y + 24,
+        },
+        {
+          components: [
+            {
+              id: paletteElement.id,
+              name: paletteElement.name,
+              type: paletteElement.type,
+              origin: 'palette',
+            },
+            {
+              id: target.id,
+              name: target.name,
+              type: target.type,
+              origin: 'board',
+            },
+          ],
+        }
+      );
+      setBoardElements((prev) =>
+        prev.filter((item) => item.id !== target.id).concat(merged)
+      );
+      setSelectedFusion((prev) => {
+        if (!prev) return prev;
+        return prev.result?.id === target.id ? null : prev;
       });
-      setBoardElements((prev) => prev.filter((item) => item.id !== target.id));
       const { added } = registerPaletteElement(result.name, result.type, 'discovered');
       setStatusMessage(
         `✨ ${paletteElement.name} y ${target.name} dieron lugar a ${result.name}. ${
@@ -495,23 +847,40 @@ function ImagineCraftWorkshop() {
       const other = boardById.get(data.boardId);
       if (!other || other.id === target.id) return;
       const result = resolveCombination(other, target);
-      const merged = {
-        id: `board-${boardCounterRef.current}`,
-        name: result.name,
-        type: result.type,
-        x: (other.x + target.x) / 2,
-        y: (other.y + target.y) / 2,
-      };
-      boardCounterRef.current += 1;
+      const merged = createBoardElement(
+        result,
+        {
+          x: coords.x,
+          y: coords.y,
+        },
+        {
+          components: [
+            {
+              id: other.id,
+              name: other.name,
+              type: other.type,
+              origin: 'board',
+            },
+            {
+              id: target.id,
+              name: target.name,
+              type: target.type,
+              origin: 'board',
+            },
+          ],
+        }
+      );
       setBoardElements((prev) =>
         prev
           .filter((item) => item.id !== target.id && item.id !== other.id)
-          .concat({
-            ...merged,
-            x: coords.x,
-            y: coords.y,
-          })
+          .concat(merged)
       );
+      setSelectedFusion((prev) => {
+        if (!prev) return prev;
+        return prev.result && (prev.result.id === target.id || prev.result.id === other.id)
+          ? null
+          : prev;
+      });
       const { added } = registerPaletteElement(result.name, result.type, 'discovered');
       setStatusMessage(
         `✨ ${other.name} y ${target.name} se fusionaron en ${result.name}. ${
@@ -533,7 +902,12 @@ function ImagineCraftWorkshop() {
             descubre resultados sorprendentes.
           </p>
         </div>
-        <div className={styles.status}>{statusMessage}</div>
+        <div className={styles.headerActions}>
+          <Link href="/" className={styles.backButton}>
+            Volver a la base
+          </Link>
+          <div className={styles.status}>{statusMessage}</div>
+        </div>
       </header>
 
       <form className={styles.creator} onSubmit={handleAddElement}>
@@ -591,6 +965,11 @@ function ImagineCraftWorkshop() {
                 onDragEnd={handleDragEnd}
                 onDrop={(event) => handleElementDrop(event, element.id)}
                 onDragOver={handleElementDragOver}
+                onClick={() =>
+                  element.components
+                    ? setSelectedFusion({ result: element, components: element.components })
+                    : setSelectedFusion(null)
+                }
               >
                 <span className={styles.tokenName}>{element.name}</span>
                 <span className={styles.tokenType}>{element.type}</span>
@@ -600,6 +979,23 @@ function ImagineCraftWorkshop() {
         </div>
         <aside className={styles.sidePanel}>
           <h2 className={styles.panelTitle}>Bitácora de mezclas</h2>
+          {selectedFusion && (
+            <div className={styles.fusionPanel}>
+              <div className={styles.fusionHeader}>
+                <h3 className={styles.fusionTitle}>{selectedFusion.result.name}</h3>
+                <p className={styles.fusionType}>{selectedFusion.result.type}</p>
+              </div>
+              <p className={styles.fusionHint}>Combinación formada por:</p>
+              <ul className={styles.fusionList}>
+                {selectedFusion.components.map((component) => (
+                  <li key={`${selectedFusion.result.id}-${component.id}`} className={styles.fusionItem}>
+                    <span className={styles.fusionItemName}>{component.name}</span>
+                    <span className={styles.fusionItemType}>{component.type}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
           <ul className={styles.logList}>
             {log.map((entry, index) => (
               <li key={`${entry}-${index}`} className={styles.logEntry}>

--- a/app/widgets/imagine-craft/ImagineCraftWorkshop.module.css
+++ b/app/widgets/imagine-craft/ImagineCraftWorkshop.module.css
@@ -23,6 +23,14 @@
   box-shadow: 0 20px 45px rgba(0, 0, 0, 0.35);
 }
 
+.headerActions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin-left: auto;
+}
+
 .breadcrumb {
   text-transform: uppercase;
   letter-spacing: 0.3em;
@@ -45,13 +53,37 @@
 }
 
 .status {
-  margin-left: auto;
   font-size: 0.95rem;
   color: rgba(255, 210, 180, 0.9);
   padding: 0.65rem 1rem;
   border-radius: 999px;
   background: linear-gradient(120deg, rgba(255, 140, 66, 0.25), rgba(255, 110, 80, 0.35));
   border: 1px solid rgba(255, 160, 120, 0.35);
+}
+
+.backButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.65rem 1.2rem;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  text-decoration: none;
+  color: rgba(255, 230, 215, 0.92);
+  border: 1px solid rgba(140, 110, 255, 0.35);
+  background: linear-gradient(115deg, rgba(70, 40, 135, 0.6), rgba(40, 26, 80, 0.75));
+  box-shadow: 0 12px 26px rgba(90, 60, 200, 0.28);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.backButton:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 32px rgba(120, 80, 220, 0.4);
+  border-color: rgba(160, 130, 255, 0.6);
 }
 
 .creator {
@@ -196,6 +228,72 @@
   margin: 0;
   font-size: 1.25rem;
   color: rgba(215, 205, 255, 0.9);
+}
+
+.fusionPanel {
+  border-radius: 18px;
+  border: 1px solid rgba(150, 120, 255, 0.35);
+  background: linear-gradient(150deg, rgba(36, 28, 60, 0.85), rgba(20, 14, 36, 0.92));
+  padding: 1rem 1.25rem;
+  display: grid;
+  gap: 0.75rem;
+  box-shadow: inset 0 0 18px rgba(150, 120, 255, 0.18);
+}
+
+.fusionHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.fusionTitle {
+  margin: 0;
+  font-size: 1.15rem;
+  color: rgba(235, 225, 255, 0.92);
+}
+
+.fusionType {
+  margin: 0;
+  font-size: 0.8rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(200, 185, 255, 0.6);
+}
+
+.fusionHint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(215, 205, 255, 0.65);
+}
+
+.fusionList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.fusionItem {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.65rem 0.75rem;
+  border-radius: 12px;
+  background: rgba(80, 60, 150, 0.22);
+  border: 1px solid rgba(150, 120, 255, 0.25);
+}
+
+.fusionItemName {
+  font-weight: 600;
+  color: rgba(235, 225, 255, 0.9);
+}
+
+.fusionItemType {
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: rgba(200, 190, 255, 0.6);
 }
 
 .logList {


### PR DESCRIPTION
## Summary
- refactor exact combination data to add new pairings, ensure self-merges, and guarantee every creation links back to a base tile
- extend Imagine Craft with additional base/result fusion recipes for richer discovery chains
- add and style a "Volver a la base" action in the workshop header for quick navigation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de227dafa883218a7e48f1d9c4d1b6