### PR TITLE
Improve Imagine Craft mobile workshop layout

### DIFF
--- a/app/widgets/imagine-craft/ImagineCraftWorkshop.module.css
+++ b/app/widgets/imagine-craft/ImagineCraftWorkshop.module.css
@@ -108,6 +108,10 @@
   gap: 0.75rem;
 }
 
+.logToggle {
+  display: none;
+}
+
 .input,
 .select {
   border-radius: 999px;
@@ -222,6 +226,29 @@
   padding: clamp(1.1rem, 0.9rem + 1vw, 1.8rem);
   display: grid;
   gap: 1.25rem;
+}
+
+.sidePanelOverlay {
+  position: fixed;
+  left: clamp(1rem, 6vw, 1.75rem);
+  right: clamp(1rem, 6vw, 1.75rem);
+  bottom: 6.25rem;
+  z-index: 30;
+  border-radius: 22px 22px 0 0;
+  box-shadow: 0 -20px 45px rgba(0, 0, 0, 0.45);
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.sidePanelOverlayHidden {
+  transform: translateY(120%);
+  opacity: 0;
+  pointer-events: none;
+}
+
+.sidePanelOverlayVisible {
+  transform: translateY(0);
+  opacity: 1;
+  pointer-events: auto;
 }
 
 .panelTitle {
@@ -393,14 +420,132 @@
 
 @media (max-width: 720px) {
   .page {
-    padding-bottom: 12rem;
+    padding: 1.25rem 1.25rem 11rem;
+    gap: 1.25rem;
+  }
+
+  .header {
+    gap: 1rem;
+  }
+
+  .status {
+    font-size: 0.8rem;
+    padding: 0.55rem 0.85rem;
+  }
+
+  .creator {
+    padding: 0.9rem 1rem 1.05rem;
+    gap: 0.6rem;
+    border-radius: 18px;
+  }
+
+  .creatorRow {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.5rem;
+  }
+
+  .input,
+  .select,
+  .button {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    font-size: 0.95rem;
+  }
+
+  .select {
+    min-width: 0;
+  }
+
+  .button {
+    text-align: center;
+  }
+
+  .logToggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    margin-top: 0.25rem;
+    padding: 0.55rem 1rem;
+    border-radius: 999px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-size: 0.7rem;
+    border: 1px solid rgba(150, 120, 255, 0.42);
+    background: rgba(30, 20, 60, 0.85);
+    color: rgba(235, 225, 255, 0.9);
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35);
+  }
+
+  .logToggleActive {
+    border-color: rgba(255, 170, 120, 0.6);
+    background: linear-gradient(135deg, rgba(255, 170, 120, 0.25), rgba(30, 20, 60, 0.9));
+    color: #ffe9d8;
+  }
+
+  .mainArea {
+    gap: 1.25rem;
   }
 
   .workspaceWrapper {
-    min-height: 320px;
+    min-height: 360px;
+    border: none;
+    border-radius: 0;
+    background: rgba(18, 10, 12, 0.85);
+  }
+
+  .workspaceHint {
+    max-width: 90%;
+    font-size: 0.9rem;
+  }
+
+  .sidePanel {
+    padding: 1rem 1.1rem 1.35rem;
+    gap: 1rem;
+  }
+
+  .sidePanelOverlay {
+    left: 1rem;
+    right: 1rem;
+    bottom: 5.75rem;
+  }
+
+  .paletteBar {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    border-radius: 18px 18px 0 0;
+    padding: 0.85rem 1.25rem 1rem;
+    gap: 0.6rem;
+    z-index: 25;
+  }
+
+  .paletteHeader h2 {
+    font-size: 1.05rem;
+  }
+
+  .paletteHeader p {
+    display: none;
   }
 
   .paletteScroller {
-    grid-auto-columns: minmax(140px, 1fr);
+    grid-auto-columns: minmax(120px, 1fr);
+    gap: 0.55rem;
+  }
+
+  .paletteItem {
+    padding: 0.6rem 0.75rem;
+    gap: 0.3rem;
+  }
+
+  .paletteName {
+    font-size: 0.95rem;
+  }
+
+  .paletteType {
+    font-size: 0.65rem;
+    letter-spacing: 0.12em;
   }
 }


### PR DESCRIPTION
## Summary
- keep the Imagine Craft palette fixed at the bottom on mobile with a denser layout and tap-to-place support
- collapse the mix log into a toggleable overlay and tighten the create-form and workspace styling for small screens
- detect touch devices to add a tap shortcut for dropping palette items into the workspace

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de619a1b6883218717fa7b98c6445f