### PR TITLE
Add Elementalist roadmap dashboard

### DIFF
--- a/app/elementalist/page.js
+++ b/app/elementalist/page.js
@@ -1,0 +1,377 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+
+const timeline = [
+  {
+    id: "week-1",
+    title: "Semana 1: Curso Sky System Secciones 2-4",
+    period: { start: "2024-10-06", end: "2024-10-12" },
+    summary: "Curso Sky System y aplicación del cielo básico al mapa.",
+    tasks: [
+      "Completar secciones de curso",
+      "Aplicar cielo básico en mapa",
+    ],
+    completedSubtasks: 1,
+  },
+  {
+    id: "week-2",
+    title: "Semana 2: Curso Sky System Secciones 5-7 + Preparar producción de mapas",
+    period: { start: "2024-10-13", end: "2024-10-19" },
+    summary: "Cierre del curso y primeros preparativos de producción.",
+    tasks: ["Completar curso", "Investigar uso Nanite/Lumen"],
+    completedSubtasks: 0,
+  },
+  {
+    id: "week-3",
+    title: "Semana 3: Mapa Páramos",
+    period: { start: "2024-10-20", end: "2024-10-26" },
+    summary: "Producción inicial del mapa de Páramos.",
+    tasks: ["Terminar mapa páramos", "Navegación básica", "Landmarks"],
+    completedSubtasks: 0,
+  },
+  {
+    id: "week-4",
+    title: "Semana 4: Pulir mapa Páramos",
+    period: { start: "2024-10-27", end: "2024-11-02" },
+    summary: "Iteración en iluminación, niebla y rendimiento de Páramos.",
+    tasks: ["Iluminacion variable", "Niebla", "Optimización fps"],
+    completedSubtasks: 0,
+  },
+  {
+    id: "week-5",
+    title: "Semana 5: Mapa nieve",
+    period: { start: "2024-11-03", end: "2024-11-09" },
+    summary: "Construcción del bioma nevado.",
+    tasks: ["Creación mapa nieve", "Navegación básica", "Landmarks"],
+    completedSubtasks: 0,
+  },
+  {
+    id: "week-6",
+    title: "Semana 6: Pulir mapa nieve",
+    period: { start: "2024-11-10", end: "2024-11-16" },
+    summary: "Puesta a punto de iluminación, niebla y optimización del bioma de nieve.",
+    tasks: ["Iluminacion variable", "Niebla", "Optimizacion"],
+    completedSubtasks: 0,
+  },
+  {
+    id: "week-7",
+    title: "Semana 7: Pulir movimiento",
+    period: { start: "2024-11-17", end: "2024-11-23" },
+    summary: "Refinamiento de locomoción, stamina y cámara.",
+    tasks: [
+      "Aceleración movimiento segun peso",
+      "Sistema stamina",
+      "Animaciones movimiento (dodge, saltos)",
+      "Camara seguimiento",
+    ],
+    completedSubtasks: 0,
+  },
+  {
+    id: "week-8",
+    title: "Semana 8: Mejorar sistema combate + Sistema de Imbuir Armas",
+    period: { start: "2024-11-24", end: "2024-11-30" },
+    summary: "Extensión del combate elemental.",
+    tasks: [
+      "Mejorar ataques basicos",
+      "Introducir nuevos ataques",
+      "Imbuir elementos a armas",
+    ],
+    completedSubtasks: 0,
+  },
+  {
+    id: "week-9",
+    title: "Semana 9: Últimos VFX y estados perjuicios/beneficios",
+    period: { start: "2024-12-01", end: "2024-12-07" },
+    summary: "Últimos efectos visuales y sonoros del combate.",
+    tasks: [
+      "VFX Tornado",
+      "VFX elementos básicos",
+      "Estados quemado, mojado y ralentizado",
+      "SFX basicos de impacto",
+    ],
+    completedSubtasks: 0,
+  },
+  {
+    id: "week-10",
+    title: "Semana 10: Comportamiento enemigos mejorado y sistema quest",
+    period: { start: "2024-12-08", end: "2024-12-14" },
+    summary: "IA y progresión.",
+    tasks: ["Bahavior tree", "Habilidad enemigo", "Sistema quest con UI", "Savegame"],
+    completedSubtasks: 0,
+  },
+  {
+    id: "week-11",
+    title: "Semana 11: Misiones + OST",
+    period: { start: "2024-12-15", end: "2024-12-21" },
+    summary: "Diseño de misiones y ambientación musical.",
+    tasks: ["Misiones tutorial", "Boss battle", "OST exploración"],
+    completedSubtasks: 0,
+  },
+  {
+    id: "week-12",
+    title: "Semana 12: Pulido misiones + SFX",
+    period: { start: "2024-12-22", end: "2024-12-28" },
+    summary: "Afinación de misiones, jefes y sonido.",
+    tasks: [
+      "Ultimas misiones",
+      "Ajustes finales boss",
+      "OST boss",
+      "Ultimos SFX",
+      "Pruebas rendimiento",
+    ],
+    completedSubtasks: 0,
+  },
+  {
+    id: "week-13",
+    title: "Semana 13: Build y packaging",
+    period: { start: "2024-12-29", end: "2025-01-04" },
+    summary: "Cierre del proyecto, build y documentación.",
+    tasks: [
+      "Hacer build",
+      "Código freeze",
+      "Readme con controles y guia",
+      "Pruebas en PCs distintos",
+    ],
+    completedSubtasks: 0,
+  },
+];
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+function getWeekStatus({ completionRatio, expectedRatio, isFuture, isPast }) {
+  if (isFuture) return { label: "Programado", tone: "neutral" };
+  if (isPast && completionRatio >= 0.999) {
+    return { label: "Completado", tone: "success" };
+  }
+  if (isPast && completionRatio < 0.999) {
+    return { label: "Pendiente", tone: "alert" };
+  }
+
+  const delta = completionRatio - expectedRatio;
+  if (delta >= 0.15) return { label: "Adelantado", tone: "success" };
+  if (delta <= -0.15) return { label: "Atrasado", tone: "alert" };
+  return { label: "En curso", tone: "info" };
+}
+
+function formatDateRange({ start, end }) {
+  const formatter = new Intl.DateTimeFormat("es-ES", {
+    day: "2-digit",
+    month: "short",
+  });
+  return `${formatter.format(start)} – ${formatter.format(end)}`;
+}
+
+function ProgressBar({ value }) {
+  return (
+    <div className="progress-track">
+      <div className="progress-fill" style={{ width: `${value * 100}%` }} />
+    </div>
+  );
+}
+
+export default function ElementalistPage() {
+  const today = new Date();
+  const [expandedWeeks, setExpandedWeeks] = useState(() =>
+    new Set(timeline.slice(0, 2).map((week) => week.id))
+  );
+
+  const summary = useMemo(() => {
+    return timeline.reduce(
+      (acc, week) => {
+        const totalTasks = week.tasks.length;
+        const completed = Math.min(week.completedSubtasks, totalTasks);
+        acc.completed += completed;
+        acc.total += totalTasks;
+        return acc;
+      },
+      { completed: 0, total: 0 }
+    );
+  }, []);
+
+  const timelineWithStatus = useMemo(() => {
+    return timeline.map((week) => {
+      const totalTasks = week.tasks.length;
+      const completed = Math.min(week.completedSubtasks, totalTasks);
+      const start = new Date(week.period.start);
+      const end = new Date(week.period.end);
+      const isFuture = today < start;
+      const isPast = today > end;
+      const completionRatio = totalTasks ? completed / totalTasks : 0;
+      let expectedRatio = 0;
+
+      if (isFuture) {
+        expectedRatio = 0;
+      } else if (isPast) {
+        expectedRatio = 1;
+      } else {
+        const elapsed = today.getTime() - start.getTime();
+        const duration = end.getTime() - start.getTime();
+        expectedRatio = duration > 0 ? clamp(elapsed / duration, 0, 1) : 0;
+      }
+
+      return {
+        ...week,
+        totalTasks,
+        completed,
+        completionRatio,
+        expectedRatio,
+        status: getWeekStatus({
+          completionRatio,
+          expectedRatio,
+          isFuture,
+          isPast,
+        }),
+        periodLabel: formatDateRange({ start, end }),
+        isFuture,
+        isCurrent: !isFuture && !isPast,
+      };
+    });
+  }, [today]);
+
+  const toggleWeek = (weekId) => {
+    setExpandedWeeks((prev) => {
+      const next = new Set(prev);
+      if (next.has(weekId)) {
+        next.delete(weekId);
+      } else {
+        next.add(weekId);
+      }
+      return next;
+    });
+  };
+
+  const overallProgress = summary.total
+    ? summary.completed / summary.total
+    : 0;
+
+  const currentWeek = timelineWithStatus.find((week) => week.isCurrent);
+
+  return (
+    <main className="elementalist-page">
+      <div className="elementalist-backdrop" />
+      <div className="elementalist-shell">
+        <header className="elementalist-hero">
+          <Link className="elementalist-hero__return" href="/">
+            ← Volver al playground
+          </Link>
+          <p className="elementalist-hero__eyebrow">Proyecto Elementalist</p>
+          <h1 className="elementalist-hero__title">Panel de progreso semanal</h1>
+          <p className="elementalist-hero__lead">
+            Un vistazo condensado al roadmap de 13 semanas del juego de mundo
+            abierto creado en Unreal Engine. Supervisa el avance, detecta si vas
+            a tiempo y mantén claras las prioridades de cada sprint.
+          </p>
+        </header>
+
+        <section className="elementalist-overview">
+          <article className="overview-card overview-card--wide">
+            <h2>Progreso general</h2>
+            <ProgressBar value={overallProgress} />
+            <div className="overview-card__stats">
+              <div>
+                <span className="overview-card__metric">
+                  {Math.round(overallProgress * 100)}%
+                </span>
+                <span className="overview-card__label">Roadmap completado</span>
+              </div>
+              <div>
+                <span className="overview-card__metric">
+                  {summary.completed}/{summary.total}
+                </span>
+                <span className="overview-card__label">Subtareas realizadas</span>
+              </div>
+            </div>
+          </article>
+
+          {currentWeek ? (
+            <article className="overview-card">
+              <h2>Semana en curso</h2>
+              <p className="overview-card__period">{currentWeek.periodLabel}</p>
+              <p className="overview-card__title">{currentWeek.title}</p>
+              <ProgressBar value={currentWeek.completionRatio} />
+              <div className="overview-card__status">
+                <span className={`status-chip status-chip--${currentWeek.status.tone}`}>
+                  {currentWeek.status.label}
+                </span>
+                <span className="overview-card__hint">
+                  {Math.round(currentWeek.completionRatio * 100)}% completado ·
+                  Esperado {Math.round(currentWeek.expectedRatio * 100)}%
+                </span>
+              </div>
+            </article>
+          ) : (
+            <article className="overview-card">
+              <h2>Semana en curso</h2>
+              <p className="overview-card__placeholder">
+                Aún no comienza el roadmap o ya finalizó.
+              </p>
+            </article>
+          )}
+        </section>
+
+        <section className="elementalist-timeline">
+          <header className="timeline-header">
+            <h2>Detalle semanal</h2>
+            <p>
+              Toca cada semana para desplegar sus subtareas. La barra lateral
+              refleja cuánto has avanzado y el indicador compara tu progreso con
+              lo esperado en el calendario.
+            </p>
+          </header>
+
+          <div className="timeline-grid">
+            {timelineWithStatus.map((week) => {
+              const isExpanded = expandedWeeks.has(week.id);
+              return (
+                <article
+                  key={week.id}
+                  className={`timeline-card${week.isCurrent ? " timeline-card--current" : ""}`}
+                >
+                  <button
+                    type="button"
+                    className="timeline-card__toggle"
+                    onClick={() => toggleWeek(week.id)}
+                  >
+                    <div className="timeline-card__header">
+                      <div className="timeline-card__headline">
+                        <span className="timeline-card__week">{week.title}</span>
+                        <span className="timeline-card__period">{week.periodLabel}</span>
+                      </div>
+                      <span
+                        className={`status-chip status-chip--${week.status.tone}`}
+                      >
+                        {week.status.label}
+                      </span>
+                    </div>
+                    <div className="timeline-card__progress">
+                      <ProgressBar value={week.completionRatio} />
+                      <span>
+                        {week.completed}/{week.totalTasks} subtareas
+                      </span>
+                    </div>
+                    <span className="timeline-card__chevron" aria-hidden>
+                      {isExpanded ? "−" : "+"}
+                    </span>
+                  </button>
+
+                  {isExpanded && (
+                    <div className="timeline-card__body">
+                      <p className="timeline-card__summary">{week.summary}</p>
+                      <ul className="timeline-card__tasks">
+                        {week.tasks.map((task) => (
+                          <li key={task}>{task}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </article>
+              );
+            })}
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -207,6 +207,48 @@ a:hover {
   box-shadow: 0 20px 45px rgba(255, 120, 40, 0.5);
 }
 
+.project-link {
+  display: grid;
+  gap: 0.35rem;
+  padding: clamp(1rem, 0.8rem + 1vw, 1.75rem);
+  border-radius: 20px;
+  text-decoration: none;
+  background:
+    linear-gradient(135deg, rgba(255, 140, 66, 0.22), rgba(20, 20, 20, 0.85)),
+    linear-gradient(120deg, rgba(255, 125, 45, 0.8), rgba(255, 90, 20, 0.15));
+  border: 1px solid rgba(255, 145, 80, 0.4);
+  box-shadow:
+    0 25px 50px rgba(0, 0, 0, 0.45),
+    inset 0 0 32px rgba(255, 132, 50, 0.18);
+  color: #ffe7d0;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.project-link__subtitle {
+  font-size: clamp(0.62rem, 0.48rem + 0.28vw, 0.78rem);
+  opacity: 0.75;
+}
+
+.project-link__title {
+  font-size: clamp(0.95rem, 0.8rem + 0.6vw, 1.2rem);
+  font-weight: 600;
+  color: #fff1e2;
+}
+
+.project-link__cta {
+  font-size: clamp(0.68rem, 0.56rem + 0.32vw, 0.85rem);
+  opacity: 0.8;
+}
+
+.project-link:hover {
+  transform: translateY(-4px);
+  box-shadow:
+    0 30px 60px rgba(0, 0, 0, 0.5),
+    inset 0 0 38px rgba(255, 132, 50, 0.22);
+}
+
 .roadmap {
   background: linear-gradient(140deg, rgba(28, 28, 28, 0.9), rgba(8, 8, 8, 0.92));
   border-radius: 20px;
@@ -388,6 +430,374 @@ a:hover {
   margin: 0;
   line-height: 1.7;
   color: rgba(255, 230, 210, 0.85);
+}
+
+.progress-track {
+  position: relative;
+  width: 100%;
+  height: 0.65rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(255, 140, 66, 0.22);
+}
+
+.progress-fill {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(120deg, #ff8f4b, #ff6b2f);
+  box-shadow: 0 12px 24px rgba(255, 120, 40, 0.3);
+}
+
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.3rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-weight: 600;
+  border: 1px solid transparent;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.status-chip--success {
+  color: #0f241a;
+  background: linear-gradient(120deg, rgba(70, 255, 172, 0.9), rgba(70, 198, 255, 0.4));
+  border-color: rgba(110, 255, 210, 0.6);
+}
+
+.status-chip--alert {
+  color: #2d0903;
+  background: linear-gradient(120deg, rgba(255, 122, 97, 0.92), rgba(255, 184, 120, 0.45));
+  border-color: rgba(255, 153, 125, 0.6);
+}
+
+.status-chip--info {
+  color: #120f2d;
+  background: linear-gradient(120deg, rgba(120, 140, 255, 0.88), rgba(160, 125, 255, 0.4));
+  border-color: rgba(155, 150, 255, 0.55);
+}
+
+.status-chip--neutral {
+  color: rgba(255, 225, 210, 0.82);
+  border-color: rgba(255, 225, 210, 0.28);
+}
+
+.elementalist-page {
+  position: relative;
+  min-height: 100dvh;
+  padding: clamp(3rem, 8vw, 5.5rem) clamp(1.5rem, 4vw, 3.5rem);
+  display: flex;
+  justify-content: center;
+  color: rgba(255, 237, 224, 0.92);
+}
+
+.elementalist-backdrop {
+  position: fixed;
+  inset: 0;
+  background:
+    radial-gradient(120% 120% at 15% 0%, rgba(255, 105, 40, 0.12), transparent 60%),
+    radial-gradient(90% 90% at 85% 20%, rgba(255, 160, 60, 0.08), transparent 65%),
+    linear-gradient(180deg, rgba(12, 12, 12, 0.95), rgba(4, 4, 4, 0.95));
+  filter: saturate(120%);
+  z-index: 0;
+}
+
+.elementalist-shell {
+  position: relative;
+  z-index: 1;
+  width: min(1120px, 100%);
+  display: grid;
+  gap: clamp(2.5rem, 4vw, 3.25rem);
+  background:
+    linear-gradient(150deg, rgba(28, 28, 28, 0.82), rgba(10, 10, 10, 0.95)),
+    linear-gradient(320deg, rgba(255, 132, 50, 0.12), rgba(50, 30, 10, 0.32));
+  border-radius: 32px;
+  border: 1px solid rgba(255, 145, 80, 0.35);
+  box-shadow:
+    0 35px 70px rgba(0, 0, 0, 0.55),
+    inset 0 0 60px rgba(255, 120, 40, 0.12);
+  padding: clamp(2.5rem, 5vw, 3.75rem);
+  backdrop-filter: blur(12px);
+}
+
+.elementalist-hero {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.elementalist-hero__return {
+  justify-self: flex-start;
+  color: rgba(255, 210, 180, 0.75);
+  text-decoration: none;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+  border: 1px solid rgba(255, 210, 180, 0.25);
+  border-radius: 999px;
+  padding: 0.45rem 1.1rem;
+  background: rgba(255, 210, 180, 0.08);
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.elementalist-hero__return:hover {
+  background: rgba(255, 210, 180, 0.16);
+  color: rgba(255, 231, 213, 0.95);
+}
+
+.elementalist-hero__eyebrow {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(255, 170, 115, 0.68);
+}
+
+.elementalist-hero__title {
+  margin: 0;
+  font-size: clamp(2.4rem, 4vw, 3.4rem);
+  color: #ffeede;
+  text-shadow: 0 18px 35px rgba(255, 120, 40, 0.22);
+}
+
+.elementalist-hero__lead {
+  margin: 0;
+  max-width: 720px;
+  line-height: 1.7;
+  color: rgba(255, 230, 210, 0.78);
+  font-size: clamp(1.05rem, 2.5vw, 1.25rem);
+}
+
+.elementalist-overview {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: clamp(1.5rem, 3vw, 2.25rem);
+}
+
+.overview-card {
+  position: relative;
+  display: grid;
+  gap: 1.1rem;
+  background:
+    linear-gradient(140deg, rgba(24, 24, 24, 0.9), rgba(6, 6, 6, 0.95)),
+    linear-gradient(320deg, rgba(255, 120, 40, 0.16), rgba(255, 90, 20, 0.08));
+  border-radius: 24px;
+  border: 1px solid rgba(255, 140, 66, 0.28);
+  padding: clamp(1.75rem, 2vw, 2.25rem);
+  box-shadow:
+    0 20px 50px rgba(0, 0, 0, 0.45),
+    inset 0 0 35px rgba(255, 120, 40, 0.1);
+}
+
+.overview-card--wide {
+  grid-column: span 2;
+}
+
+@media (max-width: 840px) {
+  .overview-card--wide {
+    grid-column: span 1;
+  }
+}
+
+.overview-card h2 {
+  margin: 0;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-size: 0.82rem;
+  color: rgba(255, 185, 120, 0.8);
+}
+
+.overview-card__stats {
+  display: flex;
+  gap: 2.5rem;
+  flex-wrap: wrap;
+  font-size: 0.85rem;
+  color: rgba(255, 224, 205, 0.75);
+}
+
+.overview-card__metric {
+  display: block;
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+  font-weight: 600;
+  color: #fff2e4;
+}
+
+.overview-card__label {
+  display: block;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.72rem;
+}
+
+.overview-card__period,
+.overview-card__title,
+.overview-card__placeholder {
+  margin: 0;
+}
+
+.overview-card__period {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 210, 185, 0.72);
+}
+
+.overview-card__title {
+  font-size: clamp(1.1rem, 2vw, 1.3rem);
+  font-weight: 500;
+  color: rgba(255, 235, 220, 0.9);
+}
+
+.overview-card__status {
+  display: flex;
+  gap: 0.85rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.overview-card__hint {
+  font-size: 0.82rem;
+  letter-spacing: 0.04em;
+  color: rgba(255, 215, 195, 0.68);
+}
+
+.overview-card__placeholder {
+  color: rgba(255, 215, 195, 0.7);
+}
+
+.elementalist-timeline {
+  display: grid;
+  gap: clamp(1.75rem, 3vw, 2.5rem);
+}
+
+.timeline-header h2 {
+  margin: 0;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-size: 0.82rem;
+  color: rgba(255, 185, 120, 0.78);
+}
+
+.timeline-header p {
+  margin: 0.75rem 0 0;
+  color: rgba(255, 230, 210, 0.75);
+  max-width: 640px;
+  line-height: 1.6;
+}
+
+.timeline-grid {
+  display: grid;
+  gap: clamp(1.25rem, 2vw, 1.8rem);
+}
+
+.timeline-card {
+  background:
+    linear-gradient(140deg, rgba(24, 24, 24, 0.85), rgba(8, 8, 8, 0.95)),
+    linear-gradient(320deg, rgba(255, 120, 40, 0.14), rgba(255, 140, 66, 0.08));
+  border-radius: 22px;
+  border: 1px solid rgba(255, 140, 66, 0.25);
+  box-shadow:
+    0 18px 45px rgba(0, 0, 0, 0.48),
+    inset 0 0 30px rgba(255, 120, 40, 0.08);
+  overflow: hidden;
+}
+
+.timeline-card--current {
+  border-color: rgba(255, 160, 90, 0.55);
+  box-shadow:
+    0 28px 65px rgba(0, 0, 0, 0.55),
+    inset 0 0 35px rgba(255, 140, 66, 0.18);
+}
+
+.timeline-card__toggle {
+  all: unset;
+  display: grid;
+  gap: 1.15rem;
+  padding: clamp(1.35rem, 2vw, 1.75rem);
+  cursor: pointer;
+}
+
+.timeline-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.timeline-card__headline {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.timeline-card__week {
+  font-size: clamp(1.05rem, 1.5vw, 1.25rem);
+  font-weight: 500;
+  color: rgba(255, 235, 220, 0.92);
+}
+
+.timeline-card__period {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 210, 185, 0.65);
+}
+
+.timeline-card__progress {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  color: rgba(255, 220, 200, 0.7);
+}
+
+.timeline-card__chevron {
+  font-size: 1.6rem;
+  justify-self: flex-end;
+  color: rgba(255, 200, 170, 0.55);
+  line-height: 1;
+}
+
+.timeline-card__body {
+  padding: 0 clamp(1.35rem, 2vw, 1.75rem) clamp(1.35rem, 2vw, 1.75rem);
+  display: grid;
+  gap: 0.9rem;
+  background: rgba(255, 140, 66, 0.05);
+  border-top: 1px solid rgba(255, 140, 66, 0.18);
+}
+
+.timeline-card__summary {
+  margin: 0;
+  color: rgba(255, 225, 205, 0.78);
+  line-height: 1.6;
+}
+
+.timeline-card__tasks {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.45rem;
+  color: rgba(255, 230, 210, 0.75);
+}
+
+.timeline-card__tasks li::marker {
+  color: rgba(255, 170, 120, 0.9);
+}
+
+@media (max-width: 640px) {
+  .elementalist-shell {
+    padding: 2.25rem clamp(1.25rem, 4vw, 1.75rem);
+  }
+
+  .elementalist-overview {
+    grid-template-columns: 1fr;
+  }
+
+  .overview-card__stats {
+    gap: 1.5rem;
+  }
 }
 
 .sudoku-grid {

--- a/app/page.js
+++ b/app/page.js
@@ -4,6 +4,12 @@ export default function HomePage() {
   return (
     <main className="welcome-page">
       <div className="zipper-frame">
+        <Link className="project-link" href="/elementalist">
+          <span className="project-link__subtitle">Roadmap destacado</span>
+          <span className="project-link__title">Seguimiento Elementalist</span>
+          <span className="project-link__cta">Ver panel de progreso</span>
+        </Link>
+
         <header className="hero">
           <h1 className="hero__title">Rodrigoplk playground</h1>
         </header>


### PR DESCRIPTION
## Summary
- add a standalone Elementalist roadmap page with weekly task data, dynamic progress calculations, and status labels
- surface a featured navigation link from the playground homepage to access the dashboard
- craft translucent orange-accented styles, progress bars, and expandable week cards for the new page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e67d0ea6c48321b694524a7b9c370a